### PR TITLE
Return indices also if population is empty

### DIFF
--- a/pymoo/core/duplicate.py
+++ b/pymoo/core/duplicate.py
@@ -20,7 +20,7 @@ class DuplicateElimination:
         original = pop
 
         if len(pop) == 0:
-            return pop
+            return (pop, [], []) if return_indices else pop
 
         if to_itself:
             pop = pop[~self._do(pop, None, np.full(len(pop), False))]


### PR DESCRIPTION
On duplicate.do, one should return index arrays if `return_indices`. Fix this corner case.