### PR TITLE
Added a "max_time" feature to the MultiObjectiveSpaceToleranceTermination class.

### DIFF
--- a/pymoo/util/termination/f_tol.py
+++ b/pymoo/util/termination/f_tol.py
@@ -26,6 +26,7 @@ class MultiObjectiveSpaceToleranceTermination(SlidingWindowTermination):
                  nth_gen=5,
                  n_max_gen=None,
                  n_max_evals=None,
+                 max_time=None,
                  **kwargs) -> None:
         super().__init__(metric_window_size=n_last,
                          data_window_size=2,
@@ -33,6 +34,7 @@ class MultiObjectiveSpaceToleranceTermination(SlidingWindowTermination):
                          nth_gen=nth_gen,
                          n_max_gen=n_max_gen,
                          n_max_evals=n_max_evals,
+                         max_time=max_time,
                          **kwargs)
         self.tol = tol
 

--- a/pymoo/util/termination/sliding_window_termination.py
+++ b/pymoo/util/termination/sliding_window_termination.py
@@ -4,6 +4,7 @@ from pymoo.util.sliding_window import SlidingWindow
 from pymoo.util.termination.collection import TerminationCollection
 from pymoo.util.termination.max_eval import MaximumFunctionCallTermination
 from pymoo.util.termination.max_gen import MaximumGenerationTermination
+from pymoo.util.termination.max_time import TimeBasedTermination
 
 
 class SlidingWindowTermination(TerminationCollection):
@@ -15,6 +16,7 @@ class SlidingWindowTermination(TerminationCollection):
                  nth_gen=1,
                  n_max_gen=None,
                  n_max_evals=None,
+                 max_time=None,
                  truncate_metrics=True,
                  truncate_data=True,
                  ) -> None:
@@ -35,7 +37,8 @@ class SlidingWindowTermination(TerminationCollection):
         """
 
         super().__init__(MaximumGenerationTermination(n_max_gen=n_max_gen),
-                         MaximumFunctionCallTermination(n_max_evals=n_max_evals))
+                         MaximumFunctionCallTermination(n_max_evals=n_max_evals),
+                         TimeBasedTermination(max_time=max_time))
 
         # the window sizes stored in objects
         self.data_window_size = data_window_size


### PR DESCRIPTION
Hi @julesy89!

Super awesome work. 

For my use case, I need the ability to decide a max time limit to allow the optimizer to run. I am optimizing several different problems, and depending on the problem, some may take longer than others. I want to use `MultiObjectiveSpaceToleranceTermination` in order to cut off the optimizer in a smart way - however as each problem in my use case is very different, it is impossible to say what the `n_max_gen` or `n_max_evals` should be. With this feature I have added, you can pass a `max_time` to the `MultiObjectiveSpaceToleranceTermination`, and it will function in the same way as `n_max_gen` or `n_max_evals`. Check the termination criteria in the way that `MultiObjectiveSpaceToleranceTermination` does, but if the `max_time` has been reached, stop optimizing and return the optima.

This allows us to choose a maximum time limit that we are willing to wait for the problem to finish in cases where we cannot say beforehand how many evals or generations it will take to reach said time limit.

Thanks for the great work.