### PR TITLE
New crowding metrics on Rank and Crowding

### DIFF
--- a/pymoo/algorithms/moo/nsga2.py
+++ b/pymoo/algorithms/moo/nsga2.py
@@ -1,18 +1,17 @@
 import numpy as np
+import warnings
 
 from pymoo.algorithms.base.genetic import GeneticAlgorithm
-from pymoo.core.survival import Survival
 from pymoo.docs import parse_doc_string
 from pymoo.operators.crossover.sbx import SBX
 from pymoo.operators.mutation.pm import PM
+from pymoo.operators.survival.rank_and_crowding import RankAndCrowding
 from pymoo.operators.sampling.rnd import FloatRandomSampling
 from pymoo.operators.selection.tournament import compare, TournamentSelection
 from pymoo.termination.default import DefaultMultiObjectiveTermination
 from pymoo.util.display.multi import MultiObjectiveOutput
 from pymoo.util.dominator import Dominator
-from pymoo.util.misc import find_duplicates, has_feasible
-from pymoo.util.nds.non_dominated_sorting import NonDominatedSorting
-from pymoo.util.randomized_argsort import randomized_argsort
+from pymoo.util.misc import has_feasible
 
 
 # ---------------------------------------------------------------------------------------------------------
@@ -68,47 +67,14 @@ def binary_tournament(pop, P, algorithm, **kwargs):
 # ---------------------------------------------------------------------------------------------------------
 
 
-class RankAndCrowdingSurvival(Survival):
-
-    def __init__(self, nds=None) -> None:
-        super().__init__(filter_infeasible=True)
-        self.nds = nds if nds is not None else NonDominatedSorting()
-
-    def _do(self, problem, pop, *args, n_survive=None, **kwargs):
-
-        # get the objective space values and objects
-        F = pop.get("F").astype(float, copy=False)
-
-        # the final indices of surviving individuals
-        survivors = []
-
-        # do the non-dominated sorting until splitting front
-        fronts = self.nds.do(F, n_stop_if_ranked=n_survive)
-
-        for k, front in enumerate(fronts):
-
-            # calculate the crowding distance of the front
-            crowding_of_front = calc_crowding_distance(F[front, :])
-
-            # save rank and crowding in the individual class
-            for j, i in enumerate(front):
-                pop[i].set("rank", k)
-                pop[i].set("crowding", crowding_of_front[j])
-
-            # current front sorted by crowding distance if splitting
-            if len(survivors) + len(front) > n_survive:
-                I = randomized_argsort(crowding_of_front, order='descending', method='numpy')
-                I = I[:(n_survive - len(survivors))]
-
-            # otherwise take the whole front unsorted
-            else:
-                I = np.arange(len(front))
-
-            # extend the survivors by all or selected individuals
-            survivors.extend(front[I])
-
-        return pop[survivors]
-
+class RankAndCrowdingSurvival(RankAndCrowding):
+    
+    def __init__(self, nds=None, crowding_func="cd"):
+        warnings.warn(
+                "RankAndCrowdingSurvival is deprecated and will be removed in version 0.8.*; use RankAndCrowding operator instead, which supports several and custom crowding diversity metrics.",
+                DeprecationWarning, 2
+            )
+        super().__init__(nds, crowding_func)
 
 # =========================================================================================================
 # Implementation
@@ -123,9 +89,10 @@ class NSGA2(GeneticAlgorithm):
                  selection=TournamentSelection(func_comp=binary_tournament),
                  crossover=SBX(eta=15, prob=0.9),
                  mutation=PM(eta=20),
-                 survival=RankAndCrowdingSurvival(),
+                 survival=RankAndCrowding(),
                  output=MultiObjectiveOutput(),
                  **kwargs):
+        
         super().__init__(
             pop_size=pop_size,
             sampling=sampling,
@@ -145,57 +112,6 @@ class NSGA2(GeneticAlgorithm):
             self.opt = self.pop[[np.argmin(self.pop.get("CV"))]]
         else:
             self.opt = self.pop[self.pop.get("rank") == 0]
-
-
-def calc_crowding_distance(F, filter_out_duplicates=True):
-    n_points, n_obj = F.shape
-
-    if n_points <= 2:
-        return np.full(n_points, np.inf)
-
-    else:
-
-        if filter_out_duplicates:
-            # filter out solutions which are duplicates - duplicates get a zero finally
-            is_unique = np.where(np.logical_not(find_duplicates(F, epsilon=1e-32)))[0]
-        else:
-            # set every point to be unique without checking it
-            is_unique = np.arange(n_points)
-
-        # index the unique points of the array
-        _F = F[is_unique]
-
-        # sort each column and get index
-        I = np.argsort(_F, axis=0, kind='mergesort')
-
-        # sort the objective space values for the whole matrix
-        _F = _F[I, np.arange(n_obj)]
-
-        # calculate the distance from each point to the last and next
-        dist = np.row_stack([_F, np.full(n_obj, np.inf)]) - np.row_stack([np.full(n_obj, -np.inf), _F])
-
-        # calculate the norm for each objective - set to NaN if all values are equal
-        norm = np.max(_F, axis=0) - np.min(_F, axis=0)
-        norm[norm == 0] = np.nan
-
-        # prepare the distance to last and next vectors
-        dist_to_last, dist_to_next = dist, np.copy(dist)
-        dist_to_last, dist_to_next = dist_to_last[:-1] / norm, dist_to_next[1:] / norm
-
-        # if we divide by zero because all values in one columns are equal replace by none
-        dist_to_last[np.isnan(dist_to_last)] = 0.0
-        dist_to_next[np.isnan(dist_to_next)] = 0.0
-
-        # sum up the distance to next and last and norm by objectives - also reorder from sorted list
-        J = np.argsort(I, axis=0)
-        _cd = np.sum(dist_to_last[J, np.arange(n_obj)] + dist_to_next[J, np.arange(n_obj)], axis=1) / n_obj
-
-        # save the final vector which sets the crowding distance for duplicates to zero to be eliminated
-        crowding = np.zeros(n_points)
-        crowding[is_unique] = _cd
-
-    # crowding[np.isinf(crowding)] = 1e+14
-    return crowding
 
 
 parse_doc_string(NSGA2.__init__)

--- a/pymoo/cython/mnn.pyx
+++ b/pymoo/cython/mnn.pyx
@@ -1,0 +1,397 @@
+# distutils: language = c++
+# cython: language_level=2, boundscheck=False, wraparound=False, cdivision=True
+
+# This was implemented using the full distances matrix
+# Other strategies can be more efficient depending on the population size and number of objectives
+# This approach was the most promising for N = 3
+# I believe for a large number of objectives M, some strategy based on upper bounds for distances would be helpful
+# Those interested in contributing please contact me at bruscalia12@gmail.com
+
+
+import numpy as np
+
+from libcpp cimport bool
+from libcpp.vector cimport vector
+from libcpp.set cimport set as cpp_set
+
+
+cdef extern from "math.h":
+    double HUGE_VAL
+
+
+def calc_mnn(double[:, :] X, int n_remove=0):
+
+    cdef:
+        int N, M, n
+        cpp_set[int] extremes
+        vector[int] extremes_min, extremes_max
+
+    N = X.shape[0]
+    M = X.shape[1]
+
+    if n_remove <= (N - M):
+        if n_remove < 0:
+            n_remove = 0
+        else:
+            pass
+    else:
+        n_remove = N - M
+
+    extremes_min = c_get_argmin(X)
+    extremes_max = c_get_argmax(X)
+
+    extremes = cpp_set[int]()
+
+    for n in extremes_min:
+        extremes.insert(n)
+
+    for n in extremes_max:
+        extremes.insert(n)
+    
+    X = c_normalize_array(X, extremes_max, extremes_min)
+
+    return c_calc_mnn(X, n_remove, N, M, extremes)
+
+
+def calc_2nn(double[:, :] X, int n_remove=0):
+
+    cdef:
+        int N, M, n
+        cpp_set[int] extremes
+        vector[int] extremes_min, extremes_max
+
+    N = X.shape[0]
+    M = X.shape[1]
+
+    if n_remove <= (N - M):
+        if n_remove < 0:
+            n_remove = 0
+        else:
+            pass
+    else:
+        n_remove = N - M
+
+    extremes_min = c_get_argmin(X)
+    extremes_max = c_get_argmax(X)
+
+    extremes = cpp_set[int]()
+
+    for n in extremes_min:
+        extremes.insert(n)
+
+    for n in extremes_max:
+        extremes.insert(n)
+
+    X = c_normalize_array(X, extremes_max, extremes_min)
+    
+    M = 2
+
+    return c_calc_mnn(X, n_remove, N, M, extremes)
+
+
+cdef c_calc_mnn(double[:, :] X, int n_remove, int N, int M, cpp_set[int] extremes):
+
+    cdef:
+        int n, mm, i, j, n_removed, k, MM
+        double dij
+        cpp_set[int] calc_items
+        cpp_set[int] H
+        double[:, :] D
+        double[:] d
+        int[:, :] Mnn
+    
+    #Define items to calculate distances
+    calc_items = cpp_set[int]()
+    for n in range(N):
+        calc_items.insert(n)
+    for n in extremes:
+        calc_items.erase(n)
+    
+    #Define remaining items to evaluate
+    H = cpp_set[int]()
+    for n in range(N):
+        H.insert(n)
+    
+    #Instantiate distances array
+    _D = np.empty((N, N), dtype=np.double)
+    D = _D[:, :]
+
+    #Shape of X
+    MM = X.shape[1]
+    
+    #Fill values on D
+    for i in range(N - 1):
+        D[i, i] = 0.0
+
+        for j in range(i + 1, N):
+
+            dij = 0
+            for mm in range(MM):
+                dij = dij + (X[j, mm] - X[i, mm]) * (X[j, mm] - X[i, mm])
+
+            D[i, j] = dij
+            D[j, i] = D[i, j]
+
+    D[N-1, N-1] = 0.0
+
+    #Initialize
+    n_removed = 0
+
+    #Initialize neighbors and distances
+    # _Mnn = np.full((N, M), -1, dtype=np.intc)
+    _Mnn = np.argpartition(D, range(1, M+1), axis=1)[:, 1:M+1].astype(np.intc)
+    dd = np.full((N,), HUGE_VAL, dtype=np.double)
+
+    Mnn = _Mnn[:, :]
+    d = dd[:]
+
+    #Obtain distance metrics
+    c_calc_d(d, Mnn, D, calc_items, M)
+
+    #While n_remove not acheived (no need to recalculate if only one item should be removed)
+    while n_removed < (n_remove - 1):
+
+        #Obtain element to drop
+        k = c_get_drop(d, H)
+        H.erase(k)
+
+        #Update index
+        n_removed = n_removed + 1
+
+        #Get items to be recalculated
+        calc_items = c_get_calc_items(Mnn, H, k, M)
+        for n in extremes:
+            calc_items.erase(n)
+        
+        #Fill in neighbors and distance matrix
+        c_calc_mnn_iter(
+                X,
+                Mnn,
+                D,
+                N, M,
+                calc_items,
+                H
+            )
+
+        #Obtain distance metrics
+        c_calc_d(d, Mnn, D, calc_items, M)
+
+    return dd
+
+
+cdef c_calc_mnn_iter(
+    double[:, :] X,
+    int[:, :] Mnn,
+    double[:, :] D,
+    int N, int M,
+    cpp_set[int] calc_items,
+    cpp_set[int] H
+    ):
+
+    cdef:
+        int i, j, m
+    
+    #Iterate over items to calculate
+    for i in calc_items:
+
+        #Iterate over elements in X
+        for j in H:
+
+            #Go to next if same element
+            if (j == i):
+                continue
+            
+            #Replace at least the last neighbor
+            elif (D[i, j] <= D[i, Mnn[i, M-1]]) or (Mnn[i, M-1] == -1):
+                
+                #Iterate over current values
+                for m in range(M):
+
+                    #Set to current if unassigned
+                    if (Mnn[i, m] == -1):
+
+                        #Set last neighbor to index
+                        Mnn[i, m] = j
+                        break
+
+                    #Break if checking already corresponding index
+                    elif (j == Mnn[i, m]):
+                        break
+
+                    #Distance satisfies condition
+                    elif (D[i, j] <= D[i, Mnn[i, m]]):
+                            
+                        #Replace higher values
+                        Mnn[i, m + 1:] = Mnn[i, m:-1]
+                        
+                        #Replace current value
+                        Mnn[i, m] = j
+                        break
+
+
+#Calculate crowding metric
+cdef c_calc_d(double[:] d, int[:, :] Mnn, double[:, :] D, cpp_set[int] calc_items, int M):
+
+    cdef:
+        int i, m
+    
+    for i in calc_items:
+
+        d[i] = 1
+        for m in range(M):
+            d[i] = d[i] * D[i, Mnn[i, m]]
+
+
+#Returns indexes of items to be recalculated after removal
+cdef cpp_set[int] c_get_calc_items(
+    int[:, :] Mnn,
+    cpp_set[int] H,
+    int k, int M):
+
+    cdef:
+        int i, m
+        cpp_set[int] calc_items
+    
+    calc_items = cpp_set[int]()
+
+    for i in H:
+
+        for m in range(M):
+
+            if Mnn[i, m] == k:
+
+                Mnn[i, m:-1] = Mnn[i, m + 1:]
+                Mnn[i, M-1] = -1
+
+                calc_items.insert(i)
+    
+    return calc_items
+
+
+#Returns elements to remove based on crowding metric d and heap of remaining elements H
+cdef int c_get_drop(double[:] d, cpp_set[int] H):
+
+    cdef:
+        int i, min_i
+        double min_d
+
+    min_d = HUGE_VAL
+    min_i = 0
+
+    for i in H:
+
+        if d[i] <= min_d:
+            min_d = d[i]
+            min_i = i
+    
+    return min_i
+
+
+#Elements in condensed matrix
+cdef int c_square_to_condensed(int i, int j, int N):
+
+    cdef int _i = i
+
+    if i < j:
+        i = j
+        j = _i
+
+    return N * j - j * (j + 1) // 2 + i - 1 - j
+
+
+#Returns vector of positions of minimum values along axis 0 of a 2d memoryview
+cdef vector[int] c_get_argmin(double[:, :] X):
+
+    cdef:
+        int N, M, min_i, n, m
+        double min_val
+        vector[int] indexes
+    
+    N = X.shape[0]
+    M = X.shape[1]
+
+    indexes = vector[int]()
+    
+    for m in range(M):
+
+        min_i = 0
+        min_val = X[0, m]
+
+        for n in range(N):
+
+            if X[n, m] < min_val:
+
+                min_i = n
+                min_val = X[n, m]
+        
+        indexes.push_back(min_i)
+    
+    return indexes
+
+
+#Returns vector of positions of maximum values along axis 0 of a 2d memoryview
+cdef vector[int] c_get_argmax(double[:, :] X):
+
+    cdef:
+        int N, M, max_i, n, m
+        double max_val
+        vector[int] indexes
+    
+    N = X.shape[0]
+    M = X.shape[1]
+
+    indexes = vector[int]()
+    
+    for m in range(M):
+
+        max_i = 0
+        max_val = X[0, m]
+
+        for n in range(N):
+
+            if X[n, m] > max_val:
+
+                max_i = n
+                max_val = X[n, m]
+        
+        indexes.push_back(max_i)
+    
+    return indexes
+
+
+#Performs normalization of a 2d memoryview
+cdef double[:, :] c_normalize_array(double[:, :] X, vector[int] extremes_max, vector[int] extremes_min):
+
+    cdef:
+        int N = X.shape[0]
+        int M = X.shape[1]
+        int n, m, l, u
+        double l_val, u_val, diff_val
+        vector[double] min_vals, max_vals
+    
+    min_vals = vector[double]()
+    max_vals = vector[double]()
+
+    m = 0
+    for u in extremes_max:
+        u_val = X[u, m]
+        max_vals.push_back(u_val)
+        m = m + 1
+    
+    m = 0
+    for l in extremes_min:
+        l_val = X[l, m]
+        min_vals.push_back(l_val)
+        m = m + 1
+    
+    for m in range(M):
+
+        diff_val = max_vals[m] - min_vals[m]
+        if diff_val == 0.0:
+            diff_val = 1.0
+
+        for n in range(N):
+
+            X[n, m] = (X[n, m] - min_vals[m]) / diff_val
+    
+    return X

--- a/pymoo/cython/pruning_cd.pyx
+++ b/pymoo/cython/pruning_cd.pyx
@@ -1,0 +1,312 @@
+# distutils: language = c++
+# cython: language_level=2, boundscheck=False, wraparound=False, cdivision=True
+
+import numpy as np
+
+from libcpp cimport bool
+from libcpp.vector cimport vector
+from libcpp.set cimport set as cpp_set
+
+
+cdef extern from "math.h":
+    double HUGE_VAL
+
+
+#Python definition
+def calc_pcd(double[:, :] X, int n_remove=0):
+
+    cdef:
+        int N, M, n
+        cpp_set[int] extremes
+        vector[int] extremes_min, extremes_max
+        int[:, :] I
+
+    N = X.shape[0]
+    M = X.shape[1]
+
+    if n_remove <= (N - M):
+        if n_remove < 0:
+            n_remove = 0
+        else:
+            pass
+    else:
+        n_remove = N - M
+
+    extremes_min = c_get_argmin(X)
+    extremes_max = c_get_argmax(X)
+
+    extremes = cpp_set[int]()
+
+    for n in extremes_min:
+        extremes.insert(n)
+
+    for n in extremes_max:
+        extremes.insert(n)
+
+    _I = np.argsort(X, axis=0, kind='mergesort').astype(np.intc)
+    I = _I[:, :]
+
+    X = c_normalize_array(X, extremes_max, extremes_min)
+
+    return c_calc_pcd(X, I, n_remove, N, M, extremes)
+
+
+#Returns crowding metrics with recursive elimination
+cdef c_calc_pcd(double[:, :] X, int[:, :] I, int n_remove, int N, int M, cpp_set[int] extremes):
+
+    cdef:
+        int n, n_removed, k
+        cpp_set[int] calc_items
+        cpp_set[int] H
+        double[:, :] D
+        double[:] d
+    
+    #Define items to calculate distances
+    calc_items = cpp_set[int]()
+    for n in range(N):
+        calc_items.insert(n)
+    for n in extremes:
+        calc_items.erase(n)
+    
+    #Define remaining items to evaluate
+    H = cpp_set[int]()
+    for n in range(N):
+        H.insert(n)
+
+    #Initialize
+    n_removed = 0
+
+    #Initialize neighbors and distances
+    _D = np.full((N, M), HUGE_VAL, dtype=np.double)
+    dd = np.full((N,), HUGE_VAL, dtype=np.double)
+
+    D = _D[:, :]
+    d = dd[:]
+
+    #Fill in neighbors and distance matrix
+    c_calc_pcd_iter(
+            X,
+            I,
+            D,
+            N, M,
+            calc_items,
+        )
+
+    #Obtain distance metrics
+    c_calc_d(d, D, calc_items, M)
+
+    #While n_remove not acheived
+    while n_removed < (n_remove - 1):
+
+        #Obtain element to drop
+        k = c_get_drop(d, H)
+        H.erase(k)
+
+        #Update index
+        n_removed = n_removed + 1
+
+        #Get items to be recalculated
+        calc_items = c_get_calc_items(I, k, M, N)
+        for n in extremes:
+            calc_items.erase(n)
+        
+        #Fill in neighbors and distance matrix
+        c_calc_pcd_iter(
+                X,
+                I,
+                D,
+                N, M,
+                calc_items,
+            )
+
+        #Obtain distance metrics
+        c_calc_d(d, D, calc_items, M)
+
+    return dd
+
+
+#Iterate
+cdef c_calc_pcd_iter(
+    double[:, :] X,
+    int[:, :] I,
+    double[:, :] D,
+    int N, int M,
+    cpp_set[int] calc_items,
+    ):
+
+    cdef:
+        int i, m, n, l, u
+    
+    #Iterate over items to calculate
+    for i in calc_items:
+
+        #Iterate over elements in X
+        for m in range(M):
+
+            for n in range(N):
+
+                if i == I[n, m]:
+
+                    l = I[n - 1, m]
+                    u = I[n + 1, m]
+
+                    D[i, m] = (X[u, m] - X[l, m]) / M
+
+
+#Calculate crowding metric
+cdef c_calc_d(double[:] d, double[:, :] D, cpp_set[int] calc_items, int M):
+
+    cdef:
+        int i, m
+    
+    for i in calc_items:
+
+        d[i] = 0
+        for m in range(M):
+            d[i] = d[i] + D[i, m]
+
+
+#Returns indexes of items to be recalculated after removal
+cdef cpp_set[int] c_get_calc_items(
+    int[:, :] I,
+    int k, int M, int N
+    ):
+
+    cdef:
+        int n, m
+        cpp_set[int] calc_items
+    
+    calc_items = cpp_set[int]()
+
+    #Iterate over all elements in I
+    for m in range(M):
+
+        for n in range(N):
+
+            if I[n, m] == k:
+
+                #Add to set of items to be recalculated
+                calc_items.insert(I[n - 1, m])
+                calc_items.insert(I[n + 1, m])
+
+                #Remove element from sorted array
+                I[n:-1, m] = I[n + 1:, m]
+    
+    return calc_items
+
+
+#Returns elements to remove based on crowding metric d and heap of remaining elements H
+cdef int c_get_drop(double[:] d, cpp_set[int] H):
+
+    cdef:
+        int i, min_i
+        double min_d
+
+    min_d = HUGE_VAL
+    min_i = 0
+
+    for i in H:
+
+        if d[i] <= min_d:
+            min_d = d[i]
+            min_i = i
+    
+    return min_i
+
+
+#Returns vector of positions of minimum values along axis 0 of a 2d memoryview
+cdef vector[int] c_get_argmin(double[:, :] X):
+
+    cdef:
+        int N, M, min_i, n, m
+        double min_val
+        vector[int] indexes
+    
+    N = X.shape[0]
+    M = X.shape[1]
+
+    indexes = vector[int]()
+    
+    for m in range(M):
+
+        min_i = 0
+        min_val = X[0, m]
+
+        for n in range(N):
+
+            if X[n, m] < min_val:
+
+                min_i = n
+                min_val = X[n, m]
+        
+        indexes.push_back(min_i)
+    
+    return indexes
+
+
+#Returns vector of positions of maximum values along axis 0 of a 2d memoryview
+cdef vector[int] c_get_argmax(double[:, :] X):
+
+    cdef:
+        int N, M, max_i, n, m
+        double max_val
+        vector[int] indexes
+    
+    N = X.shape[0]
+    M = X.shape[1]
+
+    indexes = vector[int]()
+    
+    for m in range(M):
+
+        max_i = 0
+        max_val = X[0, m]
+
+        for n in range(N):
+
+            if X[n, m] > max_val:
+
+                max_i = n
+                max_val = X[n, m]
+        
+        indexes.push_back(max_i)
+    
+    return indexes
+
+
+#Performs normalization of a 2d memoryview
+cdef double[:, :] c_normalize_array(double[:, :] X, vector[int] extremes_max, vector[int] extremes_min):
+
+    cdef:
+        int N = X.shape[0]
+        int M = X.shape[1]
+        int n, m, l, u
+        double l_val, u_val, diff_val
+        vector[double] min_vals, max_vals
+    
+    min_vals = vector[double]()
+    max_vals = vector[double]()
+
+    m = 0
+    for u in extremes_max:
+        u_val = X[u, m]
+        max_vals.push_back(u_val)
+        m = m + 1
+    
+    m = 0
+    for l in extremes_min:
+        l_val = X[l, m]
+        min_vals.push_back(l_val)
+        m = m + 1
+    
+    for m in range(M):
+
+        diff_val = max_vals[m] - min_vals[m]
+        if diff_val == 0.0:
+            diff_val = 1.0
+
+        for n in range(N):
+
+            X[n, m] = (X[n, m] - min_vals[m]) / diff_val
+    
+    return X

--- a/pymoo/operators/survival/rank_and_crowding/__init__.py
+++ b/pymoo/operators/survival/rank_and_crowding/__init__.py
@@ -1,0 +1,1 @@
+from pymoo.operators.survival.rank_and_crowding.classes import RankAndCrowding, ConstrRankAndCrowding

--- a/pymoo/operators/survival/rank_and_crowding/classes.py
+++ b/pymoo/operators/survival/rank_and_crowding/classes.py
@@ -27,7 +27,7 @@ class RankAndCrowding(Survival):
             Crowding metric. Options are:
             
                 - 'cd': crowding distances
-                - 'pcd' or 'pruned-cd': pruned crowding distances
+                - 'pcd' or 'pruning-cd': improved pruning based on crowding distances
                 - 'ce': crowding entropy
                 - 'mnn': M-Neaest Neighbors
                 - '2nn': 2-Neaest Neighbors
@@ -120,7 +120,7 @@ class ConstrRankAndCrowding(Survival):
             Crowding metric. Options are:
             
                 - 'cd': crowding distances
-                - 'pcd' or 'pruned-cd': pruned crowding distances
+                - 'pcd' or 'pruning-cd': improved pruning based on crowding distances
                 - 'ce': crowding entropy
                 - 'mnn': M-Neaest Neighbors
                 - '2nn': 2-Neaest Neighbors

--- a/pymoo/operators/survival/rank_and_crowding/classes.py
+++ b/pymoo/operators/survival/rank_and_crowding/classes.py
@@ -1,0 +1,206 @@
+import numpy as np
+from pymoo.util.randomized_argsort import randomized_argsort
+from pymoo.util.nds.non_dominated_sorting import NonDominatedSorting
+from pymoo.core.survival import Survival, split_by_feasibility
+from pymoo.core.population import Population
+from pymoo.operators.survival.rank_and_crowding.metrics import get_crowding_function
+
+
+class RankAndCrowding(Survival):
+
+    def __init__(self, nds=None, crowding_func="cd"):
+        """
+        A generalization of the NSGA-II survival operator that ranks individuals by dominance criteria
+        and sorts the last front by some user-specified crowding metric. The default is NSGA-II's crowding distances
+        although others might be more effective.
+        
+        For many-objective problems, try using 'mnn' or '2nn'.
+        
+        For Bi-objective problems, 'pcd' is very effective.
+
+        Parameters
+        ----------
+        nds : str or None, optional
+            Pymoo type of non-dominated sorting. Defaults to None.
+
+        crowding_func : str or callable, optional
+            Crowding metric. Options are:
+            
+                - 'cd': crowding distances
+                - 'pcd' or 'pruned-cd': pruned crowding distances
+                - 'ce': crowding entropy
+                - 'mnn': M-Neaest Neighbors
+                - '2nn': 2-Neaest Neighbors
+                
+            If callable, it has the form ``fun(F, filter_out_duplicates=None, n_remove=None, **kwargs)``
+            in which F (n, m) and must return metrics in a (n,) array.
+            
+            The options 'pcd', 'cd', and 'ce' are recommended for two-objective problems, whereas 'mnn' and '2nn' for many objective.
+            When using 'pcd', 'mnn', or '2nn', individuals are already eliminated in a 'single' manner. 
+            Due to Cython implementation, they are as fast as the corresponding 'cd', 'mnn-fast', or '2nn-fast', 
+            although they can singnificantly improve diversity of solutions.
+            Defaults to 'cd'.
+        """
+        
+        crowding_func_ = get_crowding_function(crowding_func)
+
+        super().__init__(filter_infeasible=True)
+        self.nds = nds if nds is not None else NonDominatedSorting()
+        self.crowding_func = crowding_func_
+        
+    def _do(self,
+            problem,
+            pop,
+            *args,
+            n_survive=None,
+            **kwargs):
+
+        # get the objective space values and objects
+        F = pop.get("F").astype(float, copy=False)
+
+        # the final indices of surviving individuals
+        survivors = []
+
+        # do the non-dominated sorting until splitting front
+        fronts = self.nds.do(F, n_stop_if_ranked=n_survive)
+
+        for k, front in enumerate(fronts):
+
+            # current front sorted by crowding distance if splitting
+            while len(survivors) + len(front) > n_survive:
+                
+                #Define how many will be removed
+                n_remove = len(survivors) + len(front) - n_survive
+                
+                # re-calculate the crowding distance of the front
+                crowding_of_front = \
+                    self.crowding_func.do(
+                        F[front, :],
+                        n_remove=n_remove
+                    )
+                
+                I = randomized_argsort(crowding_of_front, order='descending', method='numpy')
+                
+                I = I[:-n_remove]
+                front = front[I]
+
+            # otherwise take the whole front unsorted
+            else:
+                # calculate the crowding distance of the front
+                crowding_of_front = \
+                    self.crowding_func.do(
+                        F[front, :],
+                        n_remove=0
+                    )
+
+            # save rank and crowding in the individual class
+            for j, i in enumerate(front):
+                pop[i].set("rank", k)
+                pop[i].set("crowding", crowding_of_front[j])
+
+            # extend the survivors by all or selected individuals
+            survivors.extend(front)
+
+        return pop[survivors]
+
+
+class ConstrRankAndCrowding(Survival):
+    
+    def __init__(self, nds=None, crowding_func="cd"):
+        """
+        The Rank and Crowding survival approach for handling constraints proposed on
+        GDE3 by Kukkonen, S. & Lampinen, J. (2005).
+
+        Parameters
+        ----------
+        nds : str or None, optional
+            Pymoo type of non-dominated sorting. Defaults to None.
+
+        crowding_func : str or callable, optional
+            Crowding metric. Options are:
+            
+                - 'cd': crowding distances
+                - 'pcd' or 'pruned-cd': pruned crowding distances
+                - 'ce': crowding entropy
+                - 'mnn': M-Neaest Neighbors
+                - '2nn': 2-Neaest Neighbors
+                
+            If callable, it has the form ``fun(F, filter_out_duplicates=None, n_remove=None, **kwargs)``
+            in which F (n, m) and must return metrics in a (n,) array.
+            
+            The options 'pcd', 'cd', and 'ce' are recommended for two-objective problems, whereas 'mnn' and '2nn' for many objective.
+            When using 'pcd', 'mnn', or '2nn', individuals are already eliminated in a 'single' manner. 
+            Due to Cython implementation, they are as fast as the corresponding 'cd', 'mnn-fast', or '2nn-fast', 
+            although they can singnificantly improve diversity of solutions.
+            Defaults to 'cd'.
+        """
+        
+        super().__init__(filter_infeasible=False)
+        self.nds = nds if nds is not None else NonDominatedSorting()
+        self.ranking = RankAndCrowding(nds=nds, crowding_func=crowding_func)
+    
+    def _do(self,
+            problem,
+            pop,
+            *args,
+            n_survive=None,
+            **kwargs):
+
+        if n_survive is None:
+            n_survive = len(pop)
+
+        n_survive = min(n_survive, len(pop))
+
+        #If the split should be done beforehand
+        if problem.n_constr > 0:
+
+            #Split by feasibility
+            feas, infeas = split_by_feasibility(pop, eps=0.0, sort_infeasbible_by_cv=True)
+
+            #Obtain len of feasible
+            n_feas = len(feas)
+
+            #Assure there is at least_one survivor
+            if n_feas == 0:
+                survivors = Population()
+            else:
+                survivors = self.ranking.do(problem, pop[feas], *args, n_survive=min(len(feas), n_survive), **kwargs)
+
+            #Calculate how many individuals are still remaining to be filled up with infeasible ones
+            n_remaining = n_survive - len(survivors)
+
+            #If infeasible solutions need to be added
+            if n_remaining > 0:
+                
+                #Constraints to new ranking
+                G = pop[infeas].get("G")
+                G = np.maximum(G, 0)
+                
+                #Fronts in infeasible population
+                infeas_fronts = self.nds.do(G, n_stop_if_ranked=n_remaining)
+                
+                #Iterate over fronts
+                for k, front in enumerate(infeas_fronts):
+
+                    #Save ranks
+                    pop[infeas][front].set("cv_rank", k)
+
+                    #Current front sorted by CV
+                    if len(survivors) + len(front) > n_survive:
+                        
+                        #Obtain CV of front
+                        CV = pop[infeas][front].get("CV").flatten()
+                        I = randomized_argsort(CV, order='ascending', method='numpy')
+                        I = I[:(n_survive - len(survivors))]
+
+                    #Otherwise take the whole front unsorted
+                    else:
+                        I = np.arange(len(front))
+
+                    # extend the survivors by all or selected individuals
+                    survivors = Population.merge(survivors, pop[infeas][front[I]])
+
+        else:
+            survivors = self.ranking.do(problem, pop, *args, n_survive=n_survive, **kwargs)
+
+        return survivors

--- a/pymoo/operators/survival/rank_and_crowding/metrics.py
+++ b/pymoo/operators/survival/rank_and_crowding/metrics.py
@@ -1,0 +1,193 @@
+import numpy as np
+from scipy.spatial.distance import pdist, squareform
+from pymoo.util.misc import find_duplicates
+from pymoo.util.function_loader import load_function
+
+
+def get_crowding_function(label):
+
+    if label == "cd":
+        fun = FunctionalDiversity(calc_crowding_distance, filter_out_duplicates=False)
+    elif (label == "pcd") or (label == "pruning-cd"):
+        fun = FunctionalDiversity(load_function("calc_pcd"), filter_out_duplicates=True)
+    elif label == "ce":
+        fun = FunctionalDiversity(calc_crowding_entropy, filter_out_duplicates=True)
+    elif label == "mnn":
+        fun = FunctionalDiversity(load_function("calc_mnn"), filter_out_duplicates=True)
+    elif label == "2nn":
+        fun = FunctionalDiversity(load_function("calc_2nn"), filter_out_duplicates=True)
+    elif hasattr(label, "__call__"):
+        fun = FunctionalDiversity(label, filter_out_duplicates=True)
+    else:
+        raise KeyError("Crwoding function not defined")
+    return fun
+    
+
+class CrowdingDiversity:
+    
+    def do(self, F, n_remove=0):
+        #Converting types Python int to Cython int would fail in some cases converting to long instead
+        n_remove = np.intc(n_remove)
+        F = np.array(F, dtype=np.double)
+        return self._do(F, n_remove=n_remove)
+    
+    def _do(self, F, n_remove=None):
+        pass
+
+
+class FunctionalDiversity(CrowdingDiversity):
+    
+    def __init__(self, function=None, filter_out_duplicates=True):
+        self.function = function
+        self.filter_out_duplicates = filter_out_duplicates
+        super().__init__()
+    
+    def _do(self, F, **kwargs):
+        
+        n_points, n_obj = F.shape
+
+        if n_points <= F.shape[1]:
+            return np.full(n_points, np.inf)
+
+        else:
+
+            if self.filter_out_duplicates:
+                # filter out solutions which are duplicates - duplicates get a zero finally
+                is_unique = np.where(np.logical_not(find_duplicates(F, epsilon=1e-32)))[0]
+            else:
+                # set every point to be unique without checking it
+                is_unique = np.arange(n_points)
+
+            # index the unique points of the array
+            _F = F[is_unique]
+            
+            _d = self.function(_F, **kwargs)
+            
+            d = np.zeros(n_points)
+            d[is_unique] = _d
+        
+        return d
+
+
+def calc_crowding_distance(F, **kwargs):
+    n_points, n_obj = F.shape
+
+    # sort each column and get index
+    I = np.argsort(F, axis=0, kind='mergesort')
+
+    # sort the objective space values for the whole matrix
+    F = F[I, np.arange(n_obj)]
+
+    # calculate the distance from each point to the last and next
+    dist = np.row_stack([F, np.full(n_obj, np.inf)]) - np.row_stack([np.full(n_obj, -np.inf), F])
+
+    # calculate the norm for each objective - set to NaN if all values are equal
+    norm = np.max(F, axis=0) - np.min(F, axis=0)
+    norm[norm == 0] = np.nan
+
+    # prepare the distance to last and next vectors
+    dist_to_last, dist_to_next = dist, np.copy(dist)
+    dist_to_last, dist_to_next = dist_to_last[:-1] / norm, dist_to_next[1:] / norm
+
+    # if we divide by zero because all values in one columns are equal replace by none
+    dist_to_last[np.isnan(dist_to_last)] = 0.0
+    dist_to_next[np.isnan(dist_to_next)] = 0.0
+
+    # sum up the distance to next and last and norm by objectives - also reorder from sorted list
+    J = np.argsort(I, axis=0)
+    cd = np.sum(dist_to_last[J, np.arange(n_obj)] + dist_to_next[J, np.arange(n_obj)], axis=1) / n_obj
+
+    return cd
+            
+
+def calc_crowding_entropy(F, **kwargs):
+    """Wang, Y.-N., Wu, L.-H. & Yuan, X.-F., 2010. Multi-objective self-adaptive differential 
+    evolution with elitist archive and crowding entropy-based diversity measure. 
+    Soft Comput., 14(3), pp. 193-209.
+
+    Parameters
+    ----------
+    F : 2d array like
+        Objective functions.
+
+    Returns
+    -------
+    ce : 1d array
+        Crowding Entropies
+    """
+    n_points, n_obj = F.shape
+
+    # sort each column and get index
+    I = np.argsort(F, axis=0, kind='mergesort')
+
+    # sort the objective space values for the whole matrix
+    F = F[I, np.arange(n_obj)]
+
+    # calculate the distance from each point to the last and next
+    dist = np.row_stack([F, np.full(n_obj, np.inf)]) - np.row_stack([np.full(n_obj, -np.inf), F])
+
+    # calculate the norm for each objective - set to NaN if all values are equal
+    norm = np.max(F, axis=0) - np.min(F, axis=0)
+    norm[norm == 0] = np.nan
+
+    # prepare the distance to last and next vectors
+    dl = dist.copy()[:-1]
+    du = dist.copy()[1:]
+    
+    #Fix nan
+    dl[np.isnan(dl)] = 0.0
+    du[np.isnan(du)] = 0.0
+    
+    #Total distance
+    cd = dl + du
+
+    #Get relative positions
+    pl = (dl[1:-1] / cd[1:-1])
+    pu = (du[1:-1] / cd[1:-1])
+
+    #Entropy
+    entropy = np.row_stack([np.full(n_obj, np.inf),
+                            -(pl * np.log2(pl) + pu * np.log2(pu)),
+                            np.full(n_obj, np.inf)])
+    
+    #Crowding entropy
+    J = np.argsort(I, axis=0)
+    _cej = cd[J, np.arange(n_obj)] * entropy[J, np.arange(n_obj)] / norm
+    _cej[np.isnan(_cej)] = 0.0
+    ce = _cej.sum(axis=1)
+
+    return ce
+
+
+def calc_mnn_fast(F, **kwargs):
+    return _calc_mnn_fast(F, F.shape[1], **kwargs)
+    
+    
+def calc_2nn_fast(F, **kwargs):
+    return _calc_mnn_fast(F, 2, **kwargs)
+
+
+def _calc_mnn_fast(F, n_neighbors, **kwargs):
+
+    # calculate the norm for each objective - set to NaN if all values are equal
+    norm = np.max(F, axis=0) - np.min(F, axis=0)
+    norm[norm == 0] = 1.0
+    
+    # F normalized
+    F = (F - F.min(axis=0)) / norm
+    
+    # Distances pairwise (Inefficient)
+    D = squareform(pdist(F, metric="sqeuclidean"))
+    
+    # M neighbors
+    M = F.shape[1]
+    _D = np.partition(D, range(1, M+1), axis=1)[:, 1:M+1]
+    
+    # Metric d
+    d = np.prod(_D, axis=1)
+    
+    # Set top performers as np.inf
+    _extremes = np.concatenate((np.argmin(F, axis=0), np.argmax(F, axis=0)))
+    d[_extremes] = np.inf
+
+    return d

--- a/pymoo/util/function_loader.py
+++ b/pymoo/util/function_loader.py
@@ -4,6 +4,7 @@ from pymoo.config import Config
 
 
 def get_functions():
+    
     from pymoo.util.nds.fast_non_dominated_sort import fast_non_dominated_sort
     from pymoo.util.nds.efficient_non_dominated_sort import efficient_non_dominated_sort
     from pymoo.util.nds.tree_based_non_dominated_sort import tree_based_non_dominated_sort
@@ -11,6 +12,8 @@ def get_functions():
     from pymoo.util.misc import calc_perpendicular_distance
     from pymoo.util.hv import hv
     from pymoo.util.stochastic_ranking import stochastic_ranking
+    from pymoo.util.mnn import calc_mnn, calc_2nn
+    from pymoo.util.pruning_cd import calc_pcd
 
     FUNCTIONS = {
         "fast_non_dominated_sort": {
@@ -33,6 +36,15 @@ def get_functions():
         },
         "hv": {
             "python": hv, "cython": "pymoo.cython.hv"
+        },
+        "calc_mnn": {
+            "python": calc_mnn, "cython": "pymoo.cython.mnn"
+        },
+        "calc_2nn": {
+            "python": calc_2nn, "cython": "pymoo.cython.mnn"
+        },
+        "calc_pcd": {
+            "python": calc_pcd, "cython": "pymoo.cython.pruning_cd"
         },
 
     }

--- a/pymoo/util/mnn.py
+++ b/pymoo/util/mnn.py
@@ -1,0 +1,67 @@
+import numpy as np
+from scipy.spatial.distance import pdist, squareform
+
+def calc_mnn(X, n_remove=0):
+    return calc_mnn_base(X, n_remove=n_remove, twonn=False)
+
+def calc_2nn(X, n_remove=0):
+    return calc_mnn_base(X, n_remove=n_remove, twonn=True)
+
+def calc_mnn_base(X, n_remove=0, twonn=False):
+
+    N = X.shape[0]
+    M = X.shape[1]
+
+    if n_remove <= (N - M):
+        if n_remove < 0:
+            n_remove = 0
+        else:
+            pass
+    else:
+        n_remove = N - M
+    
+    if twonn:
+        M = 2
+
+    extremes_min = np.argmin(X, axis=0)
+    extremes_max = np.argmax(X, axis=0)
+    
+    min_vals = np.min(X, axis=0)
+    max_vals = np.max(X, axis=0)
+
+    extremes = np.concatenate((extremes_min, extremes_max))
+    
+    X = (X - min_vals) / (max_vals - min_vals)
+    
+    H = np.arange(N)
+    
+    D = squareform(pdist(X, metric="sqeuclidean"))
+    Dnn = np.partition(D, range(1, M+1), axis=1)[:, 1:M+1]
+    d = np.product(Dnn, axis=1)
+    d[extremes] = np.inf
+    
+    n_removed = 0
+
+    #While n_remove not acheived
+    while n_removed < (n_remove - 1):
+
+        #Obtain element to drop
+        _d = d[H]
+        _k = np.argmin(_d)
+        k = H[_k]
+        H = H[H != k]
+
+        #Update index
+        n_removed = n_removed + 1
+        if n_removed == n_remove:
+            break
+
+        else:
+
+            D[:, k] = np.inf
+            Dnn[H] = np.partition(D[H], range(1, M+1), axis=1)[:, 1:M+1]
+            d[H] = np.product(Dnn[H], axis=1)
+            d[extremes] = np.inf
+    
+    return d
+

--- a/pymoo/util/pruning_cd.py
+++ b/pymoo/util/pruning_cd.py
@@ -1,0 +1,89 @@
+import numpy as np
+
+def calc_pcd(X, n_remove=0):
+
+    N = X.shape[0]
+    M = X.shape[1]
+
+    if n_remove <= (N - M):
+        if n_remove < 0:
+            n_remove = 0
+        else:
+            pass
+    else:
+        n_remove = N - M
+
+    extremes_min = np.argmin(X, axis=0)
+    extremes_max = np.argmax(X, axis=0)
+    
+    min_vals = np.min(X, axis=0)
+    max_vals = np.max(X, axis=0)
+
+    extremes = np.concatenate((extremes_min, extremes_max))
+    
+    X = (X - min_vals) / (max_vals - min_vals)
+    
+    H = np.arange(N)
+    d = np.full(N, np.inf)
+    
+    I = np.argsort(X, axis=0, kind='mergesort')
+
+    # sort the objective space values for the whole matrix
+    _X = X[I, np.arange(M)]
+
+    # calculate the distance from each point to the last and next
+    dist = np.row_stack([_X, np.full(M, np.inf)]) - np.row_stack([np.full(M, -np.inf), _X])
+
+    # prepare the distance to last and next vectors
+    dist_to_last, dist_to_next = dist, np.copy(dist)
+    dist_to_last, dist_to_next = dist_to_last[:-1], dist_to_next[1:]
+
+    # if we divide by zero because all values in one columns are equal replace by none
+    dist_to_last[np.isnan(dist_to_last)] = 0.0
+    dist_to_next[np.isnan(dist_to_next)] = 0.0
+
+    # sum up the distance to next and last and norm by objectives - also reorder from sorted list
+    J = np.argsort(I, axis=0)
+    _d = np.sum(dist_to_last[J, np.arange(M)] + dist_to_next[J, np.arange(M)], axis=1)
+    d[H] = _d
+    d[extremes] = np.inf
+    
+    n_removed = 0
+
+    #While n_remove not acheived
+    while n_removed < (n_remove - 1):
+
+        #Obtain element to drop
+        _d = d[H]
+        _k = np.argmin(_d)
+        k = H[_k]
+        
+        H = H[H != k]
+        
+        #Update index
+        n_removed = n_removed + 1
+
+        I = np.argsort(X[H].copy(), axis=0, kind='mergesort')
+
+        # sort the objective space values for the whole matrix
+        _X = X[H].copy()[I, np.arange(M)]
+
+        # calculate the distance from each point to the last and next
+        dist = np.row_stack([_X, np.full(M, np.inf)]) - np.row_stack([np.full(M, -np.inf), _X])
+
+        # prepare the distance to last and next vectors
+        dist_to_last, dist_to_next = dist, np.copy(dist)
+        dist_to_last, dist_to_next = dist_to_last[:-1], dist_to_next[1:]
+
+        # if we divide by zero because all values in one columns are equal replace by none
+        dist_to_last[np.isnan(dist_to_last)] = 0.0
+        dist_to_next[np.isnan(dist_to_next)] = 0.0
+
+        # sum up the distance to next and last and norm by objectives - also reorder from sorted list
+        J = np.argsort(I, axis=0)
+        _d = np.sum(dist_to_last[J, np.arange(M)] + dist_to_next[J, np.arange(M)], axis=1)
+        d[H] = _d
+        d[extremes] = np.inf
+    
+    return d
+

--- a/tests/algorithms/test_nsga2.py
+++ b/tests/algorithms/test_nsga2.py
@@ -3,7 +3,7 @@ import pickle
 import numpy as np
 import pytest
 
-from pymoo.algorithms.moo.nsga2 import calc_crowding_distance
+from pymoo.operators.survival.rank_and_crowding.metrics import calc_crowding_distance
 from pymoo.util.nds.non_dominated_sorting import NonDominatedSorting
 from tests.test_util import load_to_test_resource
 

--- a/tests/misc/test_crowding_distance.py
+++ b/tests/misc/test_crowding_distance.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pytest
 
-from pymoo.algorithms.moo.nsga2 import calc_crowding_distance
+from pymoo.operators.survival.rank_and_crowding.metrics import calc_crowding_distance
 from pymoo.config import get_pymoo
 
 


### PR DESCRIPTION
Hi, Julian!

This PR will also be included when I create the PR on the DE algorithms, so you might ignore it if accept the other.

I modified the RankAndCrowdingSurival to be able to handle other metrics rather than crowding distances. I denoted the new operator as RankAndCrowding but kept the RankAndCrowdingSurvival on nsga2.py for compatibility purposes.

The other crowding metrics might be passed as a keyword argument in "crowding_func" when instantiating a RankAndCrowding operator. For now, I included the pruning strategy based on crowding distances by Kukkonen & Deb (2006a); the M-NN and 2-NN metrics by Kukkonen & Deb (2006b); and the crowding entropy metric by Wang et al. (2010) (although it does not seem to improve performance).

Furthermore, I implemented the constraint-handling strategy described in the GDE3 paper as a survival operator ConstrRankAndCrowding.

It seems to work very well :). I suggest you try NSGA-II with survival=RankAndCrowding(crowding_func="pcd") for bi-objective problems, and "mnn" for more than two objectives and verify performance.

Here are the references:

Kukkonen, S. & Deb, K., 2006a. Improved Pruning of Non-Dominated Solutions Based on Crowding Distance for Bi-Objective Optimization Problems. Vancouver, s.n., pp. 1179-1186.

Kukkonen, S. & Deb, K., 2006b. A fast and effective method for pruning of non-dominated solutions in many-objective problems. In: Parallel problem solving from nature-PPSN IX. Berlin: Springer, pp. 553-562.

Wang, Y.-N., Wu, L.-H. & Yuan, X.-F., 2010. Multi-objective self-adaptive differential evolution with elitist archive and crowding entropy-based diversity measure. Soft Comput., 14(3), pp. 193-209.

My kind regards,

Bruno Scalia