### PR TITLE
deploy CI: Add Python 3.11 and update used actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,49 +4,31 @@ on:
     branches:
       - deploy
 
-
 jobs:
-
   build:
     runs-on: "${{ matrix.os }}"
     steps:
-      -
-        uses: actions/checkout@v2
-      -
-        name: "Set up Python"
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: "Set up Python"
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python-version }}"
-      -
-        name: "Install dependencies"
+      - name: "Install dependencies"
         run: |
             python -m pip install --upgrade pip
             pip install setuptools wheel numpy cython
-      -
-        uses: knicknic/os-specific-run@v1
+      - uses: knicknic/os-specific-run@v1
         with:
           linux: "python setup.py sdist"
           macos: "python setup.py bdist_wheel"
           windows: "python setup.py bdist_wheel"
-      -
-        uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist
     strategy:
       matrix:
-        exclude:
-          -
-            os: ubuntu-latest
-            python-version: "3.7"
-          -
-            os: ubuntu-latest
-            python-version: "3.8"
-          -
-            os: ubuntu-latest
-            python-version: "3.9"
         os:
-          - ubuntu-latest
           - windows-latest
           - macos-latest
         python-version:
@@ -54,22 +36,23 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+        include:
+          - os: ubuntu-latest
+            python-version: "3.11"
+
   build-manylinux:
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v2
-      -
-        uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2010_x86_64
+      - uses: actions/checkout@v3
+      - uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2010_x86_64
         with:
           build-requirements: "cython numpy"
           pip-wheel-args: "-w ./dist --no-deps"
-          python-versions: "cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310"
-      -
-        name: "Remove non-compatible packages"
+          python-versions: "cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311"
+      - name: "Remove non-compatible packages"
         run: "sudo rm dist/*linux_x86_64.whl\n"
-      -
-        uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist


### PR DESCRIPTION
Add Python 3.11 to the deploy CI and update the used actions.