### PR TITLE
Fix setup args and sys argv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,12 +82,12 @@ data['long_description_content_type'] = 'text/x-rst'
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--nopyx', action='store_true', help='Whether the pyx files shall be considered at all.')
-parser.add_argument('--nocython', action='store_true', help='Whether pyx files shall be cythonized.')
-parser.add_argument('--nolibs', action='store_true', help='Whether the libraries should be compiled.')
+parser.add_argument('--nopyx', dest='nopyx', action='store_true', help='Whether the pyx files shall be considered at all.')
+parser.add_argument('--nocython', dest='nocython', action='store_true', help='Whether pyx files shall be cythonized.')
+parser.add_argument('--nolibs', dest='nolibs', action='store_true', help='Whether the libraries should be compiled.')
 args, _ = parser.parse_known_args()
 
-sys.argv = [e for e in sys.argv if not e in args]
+sys.argv = [e for e in sys.argv if not e.lstrip("-") in args]
 
 
 # ============================================================


### PR DESCRIPTION
Hi, Julian!

This is just a minor fix I found when trying to run setup.py locally with different --args. The attribute argv of sys stores trailing "--", so when checking if they are included in args these characters should not be considered.

My kindest regards,

Bruno Scalia