### PR TITLE
Retaining values not convertable to float64

### DIFF
--- a/pymoo/core/problem.py
+++ b/pymoo/core/problem.py
@@ -214,7 +214,7 @@ class Problem:
             try:
                 out[k] = v.astype(np.float64)
             except:
-                pass
+                out[k] = v
 
         if self.callback is not None:
             self.callback(X, out)


### PR DESCRIPTION
It might be useful to assign non float values to individuals, e.g. strings representing categories or identifiers.   
In our case, during the computational expensive evaluation of the population, we can obtain an string identifier with almost no additional costs, which would be in our case better suited for duplicate detection than a distance metric, as multiple individuals with different features might be of identical phenotype, and thus effectively reducing the variance in the population.   
  
In our local environment, this change did not introduce undesired behavior.