### PR TITLE
 Real Variable Type - Precision addition

### DIFF
--- a/pymoo/core/variable.py
+++ b/pymoo/core/variable.py
@@ -27,9 +27,10 @@ class Variable(object):
 
 class BoundedVariable(Variable):
 
-    def __init__(self, value=None, bounds=(None, None), strict=None, **kwargs) -> None:
+    def __init__(self, value=None, bounds=(None, None), strict=None, precision = 4, **kwargs) -> None:
         super().__init__(value=value, **kwargs)
         self.bounds = bounds
+        self.precision = precision
 
         if strict is None:
             strict = bounds
@@ -49,7 +50,10 @@ class Real(BoundedVariable):
 
     def _sample(self, n):
         low, high = self.bounds
-        return np.random.uniform(low=low, high=high, size=n)
+        precision = self.precision
+        self.step = 10**(-self.precision)
+        n_steps = int(np.round((high - low) / self.step))
+        return np.round(low + np.random.randint(n_steps+1, size = n) * self.step, precision)
 
 
 class Integer(BoundedVariable):

--- a/pymoo/core/variable.py
+++ b/pymoo/core/variable.py
@@ -27,7 +27,7 @@ class Variable(object):
 
 class BoundedVariable(Variable):
 
-    def __init__(self, value=None, bounds=(None, None), strict=None, precision = 4, **kwargs) -> None:
+    def __init__(self, value=None, bounds=(None, None), strict=None, precision = 6, **kwargs) -> None:
         super().__init__(value=value, **kwargs)
         self.bounds = bounds
         self.precision = precision
@@ -50,10 +50,9 @@ class Real(BoundedVariable):
 
     def _sample(self, n):
         low, high = self.bounds
-        precision = self.precision
         self.step = 10**(-self.precision)
         n_steps = int(np.round((high - low) / self.step))
-        return np.round(low + np.random.randint(n_steps+1, size = n) * self.step, precision)
+        return np.round(low + np.random.randint(n_steps+1, size = n) * self.step, self.precision)
 
 
 class Integer(BoundedVariable):


### PR DESCRIPTION
For certain cases, the Real value data type might not need a default numpy precision for sampling, if we could set precision for every variable, that would prevent unnecessary exploration in the search space