### PR TITLE
Add python 3.11 to GitHub deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           build-requirements: "cython numpy"
           pip-wheel-args: "-w ./dist --no-deps"
-          python-versions: "cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310"
+          python-versions: "cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311"
       - name: "Remove non-compatible packages"
         run: "sudo rm dist/*linux_x86_64.whl\n"
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Python 3.11 is currently only in the build target for Windows and macOS.