### PR TITLE
Fixed error in DTLZ5 docs

### DIFF
--- a/docs/source/problems/many/dtlz.ipynb
+++ b/docs/source/problems/many/dtlz.ipynb
@@ -419,7 +419,7 @@
     "\\vdots & \\vdots \\\\\n",
     "%\\mbox{Min.} & f_{M-1}(\\boldx) = (1+g(\\boldx_M)) \\cos (\\theta_1\\pi/2) \\sin (\\theta_2\\pi/2), \\\\\n",
     "\\mbox{Min.} & f_{M}(\\boldx) = (1+g(\\boldx_M)) \\sin (\\theta_1\\pi/2), \\\\\n",
-    "\\mbox{with} & \\theta_i = \\frac{\\pi}{4(1+g(\\boldx_M))}\\left(1+2g(\\boldx_M) x_i\\right), \\quad\n",
+    "\\mbox{with} & \\theta_i = \\frac{1}{2(1+g(\\boldx_M))}\\left(1+2g(\\boldx_M) x_i\\right), \\quad\n",
     "\\mbox{for $i=2,3,\\ldots,(M-1)$}, \\\\\n",
     "& g(\\boldx_M) = \\sum_{x_i \\in \\boldx_M} (x_i-0.5)^2, \\\\\n",
     "& 0 \\leq x_i \\leq 1, \\quad \\mbox{for $i=1,2,\\ldots,n$}.\n",


### PR DESCRIPTION
DTLZ5 docs differ from implementation.

Implementation was correct (solution agrees with paper).

Removed a factor of $\pi/2$ from definition of $\theta$ in docs.

This closes Issue #449 