### PR TITLE
use keyword arg, compatible with newer matplotlib

### DIFF
--- a/pymoo/visualization/util.py
+++ b/pymoo/visualization/util.py
@@ -49,7 +49,7 @@ def plot_axes_lines(ax, X, extend_factor=1.0, **kwargs):
 
 
 def plot_polygon(ax, x, **kwargs):
-    ax.add_collection(PatchCollection([patches.Polygon(x, True)], **kwargs))
+    ax.add_collection(PatchCollection([patches.Polygon(x, closed=True)], **kwargs))
 
 
 def plot_axis_labels(ax, endpoints, labels, margin=0.035, size='small', **kwargs):


### PR DESCRIPTION
Recent commit to matplotlib breaks visualization. [commit](https://github.com/matplotlib/matplotlib/commit/1fedc53c864b69284c8e8633fef0df82c87924b4)

There have been changes to __init__ parameters with the use of end-of-positional. This breaks some visualization that use `plot_polygon`

The fix is to name the parameter `closed=True`