### PR TITLE
"n_last" replaced by "period" in termination documentation

### DIFF
--- a/docs/source/interface/termination.ipynb
+++ b/docs/source/interface/termination.ipynb
@@ -115,7 +115,7 @@
     "Commonly used are the movement in the design space `f_tol` and the convergence in the constraint `cv_tol` and objective space `f_tol`.\n",
     "To provide an upper bound for the algorithm, we recommend supplying a maximum number of generations `n_max_gen` or function evaluations `n_max_evals`.\n",
     "\n",
-    "Moreover, it is worth mentioning that tolerance termination is based on a sliding window. Not only the last, but a sequence of the `n_last` generations are used to calculate compare the tolerances with an bound defined by the user."
+    "Moreover, it is worth mentioning that tolerance termination is based on a sliding window. Not only the last, but a sequence of the `period` generations are used to calculate compare the tolerances with an bound defined by the user."
    ]
   },
   {
@@ -560,7 +560,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }


### PR DESCRIPTION
On [this page](https://pymoo.org/interface/termination.html) of the documentation it seems the `n_last` should instead be `period`.

Corresponding text with `n_last` replaced with `period`.