### PR TITLE
Remove duplicate termination assign in algorithm.py

### DIFF
--- a/pymoo/core/algorithm.py
+++ b/pymoo/core/algorithm.py
@@ -66,9 +66,6 @@ class Algorithm:
         # the random seed that was used
         self.seed = seed
 
-        # an algorithm can defined the default termination which can be overwritten
-        self.termination = termination
-
         # the function evaluator object (can be used to inject code)
         if evaluator is None:
             evaluator = Evaluator()


### PR DESCRIPTION
There are dulicate termination assign in line 41 and line 70, then lines 69 to 71 of the code are removed.