### PR TITLE
Wrong Numpy Array Type When Using Choice in MixedVariableMating

### DIFF
--- a/docs/source/interface/termination.ipynb
+++ b/docs/source/interface/termination.ipynb
@@ -115,7 +115,7 @@
     "Commonly used are the movement in the design space `f_tol` and the convergence in the constraint `cv_tol` and objective space `f_tol`.\n",
     "To provide an upper bound for the algorithm, we recommend supplying a maximum number of generations `n_max_gen` or function evaluations `n_max_evals`.\n",
     "\n",
-    "Moreover, it is worth mentioning that tolerance termination is based on a sliding window. Not only the last, but a sequence of the `n_last` generations are used to calculate compare the tolerances with an bound defined by the user."
+    "Moreover, it is worth mentioning that tolerance termination is based on a sliding window. Not only the last, but a sequence of the `period` generations are used to calculate compare the tolerances with an bound defined by the user."
    ]
   },
   {
@@ -560,7 +560,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/pymoo/core/mixed.py
+++ b/pymoo/core/mixed.py
@@ -94,8 +94,11 @@ class MixedVariableMating(InfillCriterion):
             crossover = self.crossover[clazz]
             assert crossover.n_parents == XOVER_N_PARENTS and crossover.n_offsprings == XOVER_N_OFFSPRINGS
 
-            _parents = [[Individual(X=np.array([parent.X[var] for var in list_of_vars])) for parent in parents] for
-                        parents in pop]
+            _parents = [
+                [Individual(X=np.array([parent.X[var] for var in list_of_vars], dtype="O" if clazz is Choice else None)) 
+                  for parent in parents] 
+                for parents in pop
+            ]
 
             _vars = {e: vars[e] for e in list_of_vars}
             _xl = np.array([vars[e].lb if hasattr(vars[e], "lb") else None for e in list_of_vars])


### PR DESCRIPTION
Hello,

When using the `MixedVariableGA` with `MixedVariableMating` (default) with a `Choice(options=["const", "cosine"])` variable, I noticed that the following step

```python
            mutation = self.mutation[clazz]
            _off = mutation(_problem, _off, **kwargs)
```
was generating `"cosin"` instead of `"cosine"`, then I realised that the `X[mut, k] = v` affectation withing the `_do` of `ChoiceRandomMutation` was transforming `"cosine"` (correct sampled value) to `"cosin"`.

This helped me understand that `X` was a numpy array, which was probably set with a default type not compatible with any object (looked like a fixed memory reservation looking at the truncation of `"cosine"` to `"cosin"`).

Going back to the `MixedVariableMating` class, the `_parents` are by default created without `dtype`, I suggest to use `dtype="O"` for variables of type `Choice` (looking at the doc/code, it can be any object in the list passed to `Choice(options=[...])`:

```
            _parents = [
                [Individual(X=np.array([parent.X[var] for var in list_of_vars], dtype="O" if clazz is Choice else None)) 
                  for parent in parents] 
                for parents in pop
            ]
```

This resolved this quite problematic bug in my use of PyMOO.

