### PR TITLE
resolve bug that prevents two equally seeded reference direction calculations (energy reduction method) to produce the same output

### DIFF
--- a/pymoo/algorithms/moo/nsga3.py
+++ b/pymoo/algorithms/moo/nsga3.py
@@ -312,8 +312,11 @@ def get_extreme_points_c(F, ideal_point, extreme_points=None):
     __F = _F - ideal_point
     __F[__F < 1e-3] = 0
 
+    # normalize __F
+    __F_norm = (__F - np.min(__F, axis=0)) / (np.max(__F, axis=0) - np.min(__F, axis=0))
+
     # update the extreme points for the normalization having the highest asf value each
-    F_asf = np.max(__F * weights[:, None, :], axis=2)
+    F_asf = np.max(__F_norm * weights[:, None, :], axis=2)
 
     I = np.argmin(F_asf, axis=1)
     extreme_points = _F[I, :]

--- a/pymoo/util/ref_dirs/energy.py
+++ b/pymoo/util/ref_dirs/energy.py
@@ -157,7 +157,8 @@ class RieszEnergyReferenceDirectionFactory(ReferenceDirectionFactory):
                 X = ReductionBasedReferenceDirectionFactory(self.n_dim,
                                                             self.n_points,
                                                             kmeans=True,
-                                                            lexsort=False) \
+                                                            lexsort=False,
+                                                            seed=self.seed) \
                     .do()
 
             elif self.sampling == "construction":

--- a/pymoo/util/ref_dirs/reduction.py
+++ b/pymoo/util/ref_dirs/reduction.py
@@ -62,7 +62,8 @@ class ReductionBasedReferenceDirectionFactory(ReferenceDirectionFactory):
         self.n_points = n_points
 
     def _do(self):
-        rnd = sample_on_unit_simplex(self.n_sample_points, self.n_dim, unit_simplex_mapping=self.sampling)
+        rnd = sample_on_unit_simplex(self.n_sample_points, self.n_dim, unit_simplex_mapping=self.sampling,
+                                     seed=self.seed)
 
         def h(n):
             return get_partition_closest_to_points(n, self.n_dim)


### PR DESCRIPTION
Test with:

__________________________________________
import numpy as np

from pymoo.util.ref_dirs import get_reference_directions

a = get_reference_directions("energy", n_dim=3, n_points=100, seed=2)

b = get_reference_directions("energy", n_dim=3, n_points=100, seed=2)

print(np.array_equal(a, b))
___________________________________________

Behavior before change:
Expected output: True
Given output: False

Behavior after change:
Expected output: True
Given output: True

