### PR TITLE
Updated distutils.util.get_platform() to sysconfig.get_platform().

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import argparse
 import copy
-import distutils
+import sysconfig
 import os
 import sys
 import traceback
@@ -95,7 +95,7 @@ sys.argv = [e for e in sys.argv if not e.lstrip("-") in args]
 # ============================================================
 
 def is_new_osx():
-    name = distutils.util.get_platform()
+    name = sysconfig.get_platform()
     if sys.platform != "darwin":
         return False
     elif name.startswith("macosx-10"):


### PR DESCRIPTION
Python 3.12 deprecated distutils, which prevents setup.py from working in Python 3.12 environments. I updated `distutils.util.get_platform()` to `sysconfig.get_platform()` which should function the exact same.