### PR TITLE
Fix division by zero from hyperplane.

### DIFF
--- a/pymoo/algorithms/moo/age.py
+++ b/pymoo/algorithms/moo/age.py
@@ -284,7 +284,7 @@ def normalize(front, extreme):
 
     try:
         hyperplane = np.linalg.solve(front[extreme], np.ones(n))
-        if any(np.isnan(hyperplane)) or any(np.isinf(hyperplane)) or any(hyperplane < 0):
+        if any(np.isnan(hyperplane)) or any(np.isinf(hyperplane)) or any(hyperplane <= 0):
             normalization = np.max(front, axis=0)
         else:
             normalization = 1. / hyperplane
@@ -299,5 +299,6 @@ def normalize(front, extreme):
     front = front / normalization
 
     return front, normalization
+
 
 parse_doc_string(AGEMOEA.__init__)


### PR DESCRIPTION
I want to fix: https://github.com/anyoptimization/pymoo/issues/616.
I assume the fix is based on nearby code inside [normalization function](https://github.com/anyoptimization/pymoo/blob/cb3f1169846b21d26a042aa71279df171b6e5dee/pymoo/algorithms/moo/age.py#L274-L301).
`hyperplane` values are always positive, so when it is used as a denominator, the `normalization` values shall be positive.
After evaluating `normalization = 1. / hyperplane`, there is a conditional to check if `normalization` values are positive inf.
*I guess if there are zero values in `hyperplane`, it leads to some positive inf in `normalization`.
So, I just assign `np.max(front, axis=0)` to `normalization` when there are any `hyperplane` values <= 0.

*correct me if I'm wrong.
