### PR TITLE
Heatmap example fix

### DIFF
--- a/docs/source/visualization/heatmap.ipynb
+++ b/docs/source/visualization/heatmap.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "plot = Heatmap(title=(\"Optimization\", {'pad': 15}),\n",
     "               cmap=\"Oranges_r\",\n",
-    "               y_labels=[\"Solution A\", \"Solution B\", \"Solution C\", \"Solution D\"],\n",
+    "               solution_labels=[\"Solution A\", \"Solution B\", \"Solution C\", \"Solution D\"],\n",
     "               labels=[\"profit\", \"cost\", \"sustainability\", \"environment\", \"satisfaction\", \"time\"])\n",
     "plot.add(F)\n",
     "plot.show()"
@@ -133,7 +133,7 @@
     "plot = Heatmap(figsize=(10,30),\n",
     "               bound=[0,1],\n",
     "               order_by_objectives=0,\n",
-    "               y_labels=None,\n",
+    "               solution_labels=None,\n",
     "               labels=[\"profit\", \"cost\", \"sustainability\", \"environment\", \"satisfaction\", \"time\"],\n",
     "               cmap=\"Greens_r\")\n",
     "\n",

--- a/examples/visualization/heatmap.py
+++ b/examples/visualization/heatmap.py
@@ -13,7 +13,7 @@ Heatmap().add(F).show()
 # START heatmap_custom
 plot = Heatmap(title=("Optimization", {'pad': 15}),
                cmap="Oranges_r",
-               y_labels=["Solution A", "Solution B", "Solution C", "Solution D"],
+               solution_labels=["Solution A", "Solution B", "Solution C", "Solution D"],
                labels=["profit", "cost", "sustainability", "environment", "satisfaction", "time"])
 plot.add(F)
 plot.show()
@@ -26,7 +26,7 @@ plot = Heatmap(figsize=(10,30),
                bound=[0,1],
                order_by_objectives=0,
                y_labels=None,
-               labels=["profit", "cost", "sustainability", "environment", "satisfaction", "time"],
+               solution_labels=["profit", "cost", "sustainability", "environment", "satisfaction", "time"],
                cmap="Greens_r")
 
 plot.add(F, aspect=0.2)


### PR DESCRIPTION
The doc does not reflect the way heatmap visualization expects the `y_labels` and the examples does not work in labelling the solution. Its a minor fix, changing to `solution_labels` fixes the issue.