### PR TITLE
Fix for issue #620

### DIFF
--- a/examples/algorithms/moo/age2_constrained.py
+++ b/examples/algorithms/moo/age2_constrained.py
@@ -1,0 +1,64 @@
+from pymoo.indicators.igd import IGD
+from pymoo.util.ref_dirs import get_reference_directions
+from pymoo.algorithms.moo.age2 import AGEMOEA2
+from pymoo.optimize import minimize
+
+from pymoo.problems.many import C1DTLZ1, DC1DTLZ1, DC1DTLZ3, DC2DTLZ1, DC2DTLZ3, DC3DTLZ1, DC3DTLZ3, C1DTLZ3, \
+    C2DTLZ2, C3DTLZ1, C3DTLZ4
+import ray
+import numpy as np
+
+benchmark_algorithms = [
+    AGEMOEA2(),
+]
+
+benchmark_problems = [
+    C1DTLZ1, DC1DTLZ1, DC1DTLZ3, DC2DTLZ1, DC2DTLZ3, DC3DTLZ1, DC3DTLZ3, C1DTLZ3, C2DTLZ2, C3DTLZ1, C3DTLZ4
+]
+
+
+def run_benchmark(problem_class, algorithm):
+    # Instantiate the problem
+    problem = problem_class()
+
+    res = minimize(
+        problem,
+        algorithm,
+        pop_size=100,
+        verbose=True,
+        seed=1,
+        termination=('n_gen', 2000)
+    )
+
+    # Step 4: Generate the reference points
+    ref_dirs = get_reference_directions("uniform", problem.n_obj, n_points=528)
+
+    # Obtain the true Pareto front (for synthetic problems)
+    pareto_front = problem.pareto_front(ref_dirs)
+
+    # Calculate IGD
+    if res.F is None:
+        igd = np.Infinity
+    else:
+        igd = IGD(pareto_front)(res.F)
+
+    result = {
+        "problem": problem,
+        "algorithm": algorithm,
+        "result": res,
+        "igd": igd
+    }
+
+    return result
+
+
+tasks = []
+for problem in benchmark_problems:
+    for algorithm in benchmark_algorithms:
+        tasks.append(ray.remote(run_benchmark).remote(problem, algorithm))
+result = ray.get(tasks)
+
+for res in result:
+    print(f"Algorithm = {res['algorithm'].__class__.__name__}, "
+          f"Problem = {res['problem'].__class__.__name__}, "
+          f"IGD = {res['igd']}")

--- a/pymoo/algorithms/moo/age.py
+++ b/pymoo/algorithms/moo/age.py
@@ -209,7 +209,7 @@ class AGEMOEASurvival(Survival):
         return p
 
     @staticmethod
-    @jit(fastmath=True)
+    @jit(nopython=True, fastmath=True)
     def pairwise_distances(front, p):
         m = np.shape(front)[0]
         distances = np.zeros((m, m))
@@ -219,7 +219,7 @@ class AGEMOEASurvival(Survival):
         return distances
 
     @staticmethod
-    @jit(fastmath=True)
+    @jit(nopython=True, fastmath=True)
     def minkowski_distances(A, B, p):
         m1 = np.shape(A)[0]
         m2 = np.shape(B)[0]
@@ -254,7 +254,7 @@ def find_corner_solutions(front):
     return indexes
 
 
-@jit(fastmath=True)
+@jit(nopython=True, fastmath=True)
 def point_2_line_distance(P, A, B):
     d = np.zeros(P.shape[0])
 

--- a/pymoo/algorithms/moo/age.py
+++ b/pymoo/algorithms/moo/age.py
@@ -167,7 +167,13 @@ class AGEMOEASurvival(Survival):
         p = self.compute_geometry(front, extreme, n)
 
         nn = np.linalg.norm(front, p, axis=1)
-        distances = self.pairwise_distances(front, p) / (nn[:, None])
+        # Replace very small norms with 1 to prevent division by zero
+        nn[nn < 1e-8] = 1
+
+        distances = self.pairwise_distances(front, p)
+        distances[distances < 1e-8] = 1e-8  # Replace very small entries to prevent division by zero
+
+        distances = distances / (nn[:, None])
 
         neighbors = 2
         remaining = np.arange(m)
@@ -209,7 +215,7 @@ class AGEMOEASurvival(Survival):
         return p
 
     @staticmethod
-    @jit(nopython=True, fastmath=True)
+    #@jit(nopython=True, fastmath=True)
     def pairwise_distances(front, p):
         m = np.shape(front)[0]
         distances = np.zeros((m, m))

--- a/pymoo/algorithms/moo/age2.py
+++ b/pymoo/algorithms/moo/age2.py
@@ -94,8 +94,11 @@ def find_zero(point, n, precision):
                 numerator += power_value * np.log(point[obj_index] + epsilon)
                 denominator += power_value
 
-        if denominator == 0:
-            return 1  # Handle division by zero
+        if denominator == 0 or np.isnan(denominator) or np.isinf(denominator):
+            return 1  # Handle division by zero or NaN
+
+        if np.isnan(numerator) or np.isinf(numerator):
+            return 1  # Handle division with Nan or Inf
 
         ff = numerator / denominator
 

--- a/pymoo/algorithms/moo/age2.py
+++ b/pymoo/algorithms/moo/age2.py
@@ -81,7 +81,11 @@ def find_zero(point, n, precision):
         f = 0.0
         for obj_index in range(0, n):
             if point[obj_index] > 0:
-                f += np.power(point[obj_index] + epsilon, x)
+                log_value = x * np.log(point[obj_index] + epsilon)
+                if log_value < np.log(np.finfo(np.float64).max):
+                    f += np.exp(log_value)
+                else:
+                    return 1  # Handle overflow by returning a fallback value
 
         f = np.log(f) if f > 0 else 0  # Avoid log of non-positive numbers
 
@@ -90,22 +94,26 @@ def find_zero(point, n, precision):
         denominator = 0
         for obj_index in range(0, n):
             if point[obj_index] > 0:
-                power_value = np.power(point[obj_index] + epsilon, x)
-                numerator += power_value * np.log(point[obj_index] + epsilon)
-                denominator += power_value
+                log_value = x * np.log(point[obj_index] + epsilon)
+                if log_value < np.log(np.finfo(np.float64).max):
+                    power_value = np.exp(log_value)
+                    numerator += power_value * np.log(point[obj_index] + epsilon)
+                    denominator += power_value
+                else:
+                    return 1  # Handle overflow by returning a fallback value
 
         if denominator == 0 or np.isnan(denominator) or np.isinf(denominator):
             return 1  # Handle division by zero or NaN
 
         if np.isnan(numerator) or np.isinf(numerator):
-            return 1  # Handle division with Nan or Inf
+            return 1  # Handle invalid numerator
 
         ff = numerator / denominator
 
-        if ff == 0:  # Check for zero denominator before division
+        if ff == 0:  # Check for zero before division
             return 1  # Handle by returning a fallback value
 
-        # Zero of function
+        # Update x using Newton's method
         x = x - f / ff
 
         if abs(x - past_value) <= precision:

--- a/pymoo/algorithms/moo/age2.py
+++ b/pymoo/algorithms/moo/age2.py
@@ -64,7 +64,7 @@ class AGEMOEA2(GeneticAlgorithm):
         self.tournament_type = 'comp_by_rank_and_crowding'
 
 
-@jit(fastmath=True)
+@jit(nopython=True, fastmath=True)
 def project_on_manifold(point, p):
     dist = sum(point[point > 0] ** p) ** (1/p)
     return np.multiply(point, 1 / dist)
@@ -140,7 +140,7 @@ class AGEMOEA2Survival(AGEMOEASurvival):
         return p
 
     @staticmethod
-    @jit(fastmath=True)
+    @jit(nopython=True, fastmath=True)
     def pairwise_distances(front, p):
         m, n = front.shape
         projected_front = front.copy()

--- a/pymoo/algorithms/moo/age2.py
+++ b/pymoo/algorithms/moo/age2.py
@@ -72,40 +72,45 @@ def project_on_manifold(point, p):
 
 def find_zero(point, n, precision):
     x = 1
-
+    epsilon = 1e-10  # Small constant for regularization
     past_value = x
+
     for i in range(0, 100):
 
-        # Original function
+        # Original function with regularization
         f = 0.0
         for obj_index in range(0, n):
             if point[obj_index] > 0:
-                f += np.power(point[obj_index], x)
+                f += np.power(point[obj_index] + epsilon, x)
 
-        f = np.log(f)
+        f = np.log(f) if f > 0 else 0  # Avoid log of non-positive numbers
 
-        # Derivative
+        # Derivative with regularization
         numerator = 0
         denominator = 0
         for obj_index in range(0, n):
             if point[obj_index] > 0:
-                numerator = numerator + np.power(point[obj_index], x) * np.log(point[obj_index])
-                denominator = denominator + np.power(point[obj_index], x)
+                power_value = np.power(point[obj_index] + epsilon, x)
+                numerator += power_value * np.log(point[obj_index] + epsilon)
+                denominator += power_value
 
         if denominator == 0:
-            return 1
+            return 1  # Handle division by zero
 
         ff = numerator / denominator
 
-        # zero of function
+        if ff == 0:  # Check for zero denominator before division
+            return 1  # Handle by returning a fallback value
+
+        # Zero of function
         x = x - f / ff
 
         if abs(x - past_value) <= precision:
             break
         else:
-            paste_value = x  # update current point
+            past_value = x  # Update current point
 
-    if isinstance(x, complex):
+    if isinstance(x, complex) or np.isinf(x) or np.isnan(x):
         return 1
     else:
         return x


### PR DESCRIPTION
This PR fixes the error in issue #620 

The previous implementation can lead to division by zero or extremely large exponential values that can lead to overflow problems for constrained problems.

This PR fixes these errors as follows:

- Regularization with epsilon: The small constant epsilon is added to each value of `point[obj_index]` before raising it to the power of `x`. This prevents the base of the exponentiation from becoming too small, which can lead to extremely large results when `x` is large.
- Logarithm Handling: The logarithm calculation is adjusted to prevent taking the log of non-positive numbers.
- Zero Handling: If the denominator (`denominator`) or the derivative (`ff`) is zero, the function returns a fallback value to avoid division by zero.