### PR TITLE
Fix numba warning

### DIFF
--- a/examples/algorithms/moo/age2_constrained.py
+++ b/examples/algorithms/moo/age2_constrained.py
@@ -1,0 +1,64 @@
+from pymoo.indicators.igd import IGD
+from pymoo.util.ref_dirs import get_reference_directions
+from pymoo.algorithms.moo.age2 import AGEMOEA2
+from pymoo.optimize import minimize
+
+from pymoo.problems.many import C1DTLZ1, DC1DTLZ1, DC1DTLZ3, DC2DTLZ1, DC2DTLZ3, DC3DTLZ1, DC3DTLZ3, C1DTLZ3, \
+    C2DTLZ2, C3DTLZ1, C3DTLZ4
+import ray
+import numpy as np
+
+benchmark_algorithms = [
+    AGEMOEA2(),
+]
+
+benchmark_problems = [
+    C1DTLZ1, DC1DTLZ1, DC1DTLZ3, DC2DTLZ1, DC2DTLZ3, DC3DTLZ1, DC3DTLZ3, C1DTLZ3, C2DTLZ2, C3DTLZ1, C3DTLZ4
+]
+
+
+def run_benchmark(problem_class, algorithm):
+    # Instantiate the problem
+    problem = problem_class()
+
+    res = minimize(
+        problem,
+        algorithm,
+        pop_size=100,
+        verbose=True,
+        seed=1,
+        termination=('n_gen', 2000)
+    )
+
+    # Step 4: Generate the reference points
+    ref_dirs = get_reference_directions("uniform", problem.n_obj, n_points=528)
+
+    # Obtain the true Pareto front (for synthetic problems)
+    pareto_front = problem.pareto_front(ref_dirs)
+
+    # Calculate IGD
+    if res.F is None:
+        igd = np.Infinity
+    else:
+        igd = IGD(pareto_front)(res.F)
+
+    result = {
+        "problem": problem,
+        "algorithm": algorithm,
+        "result": res,
+        "igd": igd
+    }
+
+    return result
+
+
+tasks = []
+for problem in benchmark_problems:
+    for algorithm in benchmark_algorithms:
+        tasks.append(ray.remote(run_benchmark).remote(problem, algorithm))
+result = ray.get(tasks)
+
+for res in result:
+    print(f"Algorithm = {res['algorithm'].__class__.__name__}, "
+          f"Problem = {res['problem'].__class__.__name__}, "
+          f"IGD = {res['igd']}")

--- a/pymoo/algorithms/moo/age.py
+++ b/pymoo/algorithms/moo/age.py
@@ -209,7 +209,7 @@ class AGEMOEASurvival(Survival):
         return p
 
     @staticmethod
-    @jit(fastmath=True)
+    @jit(nopython=True, fastmath=True)
     def pairwise_distances(front, p):
         m = np.shape(front)[0]
         distances = np.zeros((m, m))
@@ -219,7 +219,7 @@ class AGEMOEASurvival(Survival):
         return distances
 
     @staticmethod
-    @jit(fastmath=True)
+    @jit(nopython=True, fastmath=True)
     def minkowski_distances(A, B, p):
         m1 = np.shape(A)[0]
         m2 = np.shape(B)[0]
@@ -254,7 +254,7 @@ def find_corner_solutions(front):
     return indexes
 
 
-@jit(fastmath=True)
+@jit(nopython=True, fastmath=True)
 def point_2_line_distance(P, A, B):
     d = np.zeros(P.shape[0])
 

--- a/pymoo/algorithms/moo/age2.py
+++ b/pymoo/algorithms/moo/age2.py
@@ -64,7 +64,7 @@ class AGEMOEA2(GeneticAlgorithm):
         self.tournament_type = 'comp_by_rank_and_crowding'
 
 
-@jit(fastmath=True)
+@jit(nopython=True, fastmath=True)
 def project_on_manifold(point, p):
     dist = sum(point[point > 0] ** p) ** (1/p)
     return np.multiply(point, 1 / dist)
@@ -140,7 +140,7 @@ class AGEMOEA2Survival(AGEMOEASurvival):
         return p
 
     @staticmethod
-    @jit(fastmath=True)
+    @jit(nopython=True, fastmath=True)
     def pairwise_distances(front, p):
         m, n = front.shape
         projected_front = front.copy()

--- a/pymoo/algorithms/moo/age2.py
+++ b/pymoo/algorithms/moo/age2.py
@@ -72,40 +72,45 @@ def project_on_manifold(point, p):
 
 def find_zero(point, n, precision):
     x = 1
-
+    epsilon = 1e-10  # Small constant for regularization
     past_value = x
+
     for i in range(0, 100):
 
-        # Original function
+        # Original function with regularization
         f = 0.0
         for obj_index in range(0, n):
             if point[obj_index] > 0:
-                f += np.power(point[obj_index], x)
+                f += np.power(point[obj_index] + epsilon, x)
 
-        f = np.log(f)
+        f = np.log(f) if f > 0 else 0  # Avoid log of non-positive numbers
 
-        # Derivative
+        # Derivative with regularization
         numerator = 0
         denominator = 0
         for obj_index in range(0, n):
             if point[obj_index] > 0:
-                numerator = numerator + np.power(point[obj_index], x) * np.log(point[obj_index])
-                denominator = denominator + np.power(point[obj_index], x)
+                power_value = np.power(point[obj_index] + epsilon, x)
+                numerator += power_value * np.log(point[obj_index] + epsilon)
+                denominator += power_value
 
         if denominator == 0:
-            return 1
+            return 1  # Handle division by zero
 
         ff = numerator / denominator
 
-        # zero of function
+        if ff == 0:  # Check for zero denominator before division
+            return 1  # Handle by returning a fallback value
+
+        # Zero of function
         x = x - f / ff
 
         if abs(x - past_value) <= precision:
             break
         else:
-            paste_value = x  # update current point
+            past_value = x  # Update current point
 
-    if isinstance(x, complex):
+    if isinstance(x, complex) or np.isinf(x) or np.isnan(x):
         return 1
     else:
         return x


### PR DESCRIPTION
AGE-MOEA and AGE-MOEA-II raise Numba Warnings:

`NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.`

To address this warning and prepare for future versions of Numba, this PR explicitly specifies the `nopython` argument in the `@jit `decorator.