### PR TITLE
Fix compatibility with numpy 2.0 and allow use of last version of cma

### DIFF
--- a/pymoo/algorithms/soo/nonconvex/es.py
+++ b/pymoo/algorithms/soo/nonconvex/es.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 
 from pymoo.algorithms.base.genetic import GeneticAlgorithm
 from pymoo.algorithms.soo.nonconvex.ga import FitnessSurvival
@@ -43,9 +44,9 @@ class ES(GeneticAlgorithm):
         """
 
         if pop_size is None and n_offsprings is not None:
-            pop_size = int(np.math.ceil(n_offsprings * rule))
+            pop_size = int(math.ceil(n_offsprings * rule))
         elif n_offsprings is None and pop_size is not None:
-            n_offsprings = int(np.math.floor(pop_size / rule))
+            n_offsprings = int(math.floor(pop_size / rule))
 
         assert pop_size is not None and n_offsprings is not None, "You have to at least provivde pop_size of n_offsprings."
         assert n_offsprings >= 2 * pop_size, "The number of offsprings should be at least double the population size."

--- a/pymoo/util/mnn.py
+++ b/pymoo/util/mnn.py
@@ -40,7 +40,7 @@ def calc_mnn_base(X, n_remove=0, twonn=False):
     
     D = squareform(pdist(X, metric="sqeuclidean"))
     Dnn = np.partition(D, range(1, M+1), axis=1)[:, 1:M+1]
-    d = np.product(Dnn, axis=1)
+    d = np.prod(Dnn, axis=1)
     d[extremes] = np.inf
     
     n_removed = 0
@@ -63,7 +63,7 @@ def calc_mnn_base(X, n_remove=0, twonn=False):
 
             D[:, k] = np.inf
             Dnn[H] = np.partition(D[H], range(1, M+1), axis=1)[:, 1:M+1]
-            d[H] = np.product(Dnn[H], axis=1)
+            d[H] = np.prod(Dnn[H], axis=1)
             d[extremes] = np.inf
     
     return d

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ data = dict(
                       'scipy>=1.1',
                       'matplotlib>=3',
                       'autograd>=1.4',
-                      'cma==3.2.2',
+                      'cma>=3.2.2',
                       'alive-progress',
                       'dill',
                       'Deprecated'],


### PR DESCRIPTION
Make pymoo compatible with numpy 2.0 by :
* Replacing old numpy modules that have been removed (np.math -> math, np.product -> np.prod)
* Allowing cma>3.2.2 (cma is compatible with numpy 2.0 since version 3.4.0)

Since pymoo is a library and is compatible with all cma versions between 3.2.2 to the latest version, the requirement has only been relaxed, so users are allowed to keep using cma 3.2.2 (together with older numpy versions) if they wish to.

Tests have been performed locally with Python 11, numpy 2.0.1 and cma 3.4.0.

Note that the tests done in the github workflow on the main branch fail. I have tested that no new errors have been introduced, but already existing errors remain present.