### PR TITLE
Update ox.py

### DIFF
--- a/pymoo/operators/crossover/ox.py
+++ b/pymoo/operators/crossover/ox.py
@@ -36,7 +36,7 @@ def ox(receiver, donor, seq=None, shift=False):
     assert len(donor) == len(receiver)
 
     # the sequence which shall be use for the crossover
-    seq = seq if not None else random_sequence(len(receiver))
+    seq = seq if seq is not None else random_sequence(len(receiver))
     start, end = seq
 
     # the donation and a set of it to allow a quick lookup


### PR DESCRIPTION
- Fix typo in None check: the condition `if not None` doesn't actually check the value of `seq`. Instead, it's just a static check against `None`, which doesn't achieve what we want. We probably meant to check whether `seq `is None.