### PR TITLE
Fixed sum to ensure numba type copatability

### DIFF
--- a/pymoo/algorithms/moo/age.py
+++ b/pymoo/algorithms/moo/age.py
@@ -232,7 +232,7 @@ class AGEMOEASurvival(Survival):
         distances = np.zeros((m1, m2))
         for i in range(m1):
             for j in range(m2):
-                distances[i][j] = sum(np.abs(A[i] - B[j]) ** p) ** (1 / p)
+                distances[i][j] = np.sum(np.abs(A[i] - B[j]) ** p) ** (1 / p)
 
         return distances
 
@@ -262,13 +262,13 @@ def find_corner_solutions(front):
 
 @jit(nopython=True, fastmath=True)
 def point_2_line_distance(P, A, B):
-    d = np.zeros(P.shape[0])
+    d = np.zeros(P.shape[0], dtype=numba.float64)
 
     for i in range(P.shape[0]):
         pa = P[i] - A
         ba = B - A
         t = np.dot(pa, ba) / np.dot(ba, ba)
-        d[i] = sum((pa - t * ba) ** 2)
+        d[i] = np.sum((pa - t * ba) ** 2)
 
     return d
 

--- a/pymoo/algorithms/moo/age2.py
+++ b/pymoo/algorithms/moo/age2.py
@@ -66,7 +66,7 @@ class AGEMOEA2(GeneticAlgorithm):
 
 @jit(nopython=True, fastmath=True)
 def project_on_manifold(point, p):
-    dist = sum(point[point > 0] ** p) ** (1/p)
+    dist = np.sum(point[point > 0] ** p) ** (1/p)
     return np.multiply(point, 1 / dist)
 
 
@@ -178,7 +178,7 @@ class AGEMOEA2Survival(AGEMOEASurvival):
         if 0.95 < p < 1.05:
             for row in range(0, m - 1):
                 for column in range(row + 1, m):
-                    distances[row][column] = sum(np.abs(projected_front[row] - projected_front[column]) ** 2) ** 0.5
+                    distances[row][column] = np.sum(np.abs(projected_front[row] - projected_front[column]) ** 2) ** 0.5
 
         else:
             for row in range(0, m-1):
@@ -186,8 +186,8 @@ class AGEMOEA2Survival(AGEMOEASurvival):
                     mid_point = projected_front[row] * 0.5 + projected_front[column] * 0.5
                     mid_point = project_on_manifold(mid_point, p)
 
-                    distances[row][column] = sum(np.abs(projected_front[row] - mid_point) ** 2) ** 0.5 + \
-                                            sum(np.abs(projected_front[column] - mid_point) ** 2) ** 0.5
+                    distances[row][column] = np.sum(np.abs(projected_front[row] - mid_point) ** 2) ** 0.5 + \
+                                            np.sum(np.abs(projected_front[column] - mid_point) ** 2) ** 0.5
 
         return distances + distances.T
 


### PR DESCRIPTION
In AGE-MOEA and AGE-MOEA2 need numba to run. However the python `sum` function produces errors due to issues with type checking.

Changing to `np.sum` fixes the issue.

Furthermore defining return type of `point_2_line_distance` removes type issues.