### PR TITLE
Fixed Divsion by 0 Error in Normalization

### DIFF
--- a/pymoo/util/normalization.py
+++ b/pymoo/util/normalization.py
@@ -66,7 +66,7 @@ class ZeroToOneNormalization(Normalization):
         # now create all the masks that are necessary
         self.xl_only, self.xu_only = np.logical_and(~xl_nan, xu_nan), np.logical_and(xl_nan, ~xu_nan)
         self.both_nan = np.logical_and(np.isnan(xl), np.isnan(xu))
-        self.neither_nan = ~self.both_nan
+        self.neither_nan = np.logical_and(~np.isnan(xl), ~np.isnan(xu))
 
         # if neither is nan than xu must be greater or equal than xl
         any_nan = np.logical_or(np.isnan(xl), np.isnan(xu))
@@ -76,18 +76,15 @@ class ZeroToOneNormalization(Normalization):
         if X is None or (self.xl is None and self.xu is None):
             return X
 
-        xl, xu, xl_only, xu_only = self.xl, self.xu, self.xl_only, self.xu_only
-        both_nan, neither_nan = self.both_nan, self.neither_nan
-
         # simple copy the input
         N = np.copy(X)
 
         # normalize between zero and one if neither of them is nan
-        N[..., neither_nan] = (X[..., neither_nan] - xl[neither_nan]) / (xu[neither_nan] - xl[neither_nan])
+        N[...,  self.neither_nan] = (X[...,  self.neither_nan] - self.xl[self.neither_nan]) / (self.xu[self.neither_nan] - self.xl[self.neither_nan])
 
-        N[..., xl_only] = X[..., xl_only] - xl[xl_only]
+        N[..., self.xl_only] = X[..., self.xl_only] - self.xl[self.xl_only]
 
-        N[..., xu_only] = 1.0 - (xu[xu_only] - X[..., xu_only])
+        N[..., self.xu_only] = 1.0 - (self.xu[self.xu_only] - X[..., self.xu_only])
 
         return N
 


### PR DESCRIPTION
`self.neither_nan` in [pymoo/util/normalization.py](https://github.com/anyoptimization/pymoo/pull/668/files#diff-1d41ccdc2aa4a0fe7681194dcae80e3f6b9cba5e34b8a4c726613d8d841dd108) had a wrong conditional statement. It was ~(a ^ b), but should have been ~a ^~b.

Closes #637

