### PR TITLE
fixes some typos and grammatical errors

### DIFF
--- a/docs/source/algorithms/moo/kgb.ipynb
+++ b/docs/source/algorithms/moo/kgb.ipynb
@@ -77,7 +77,7 @@
     "- **perc_diversity (float, optional):** Proportion of the population allocated for introducing diversity. \n",
     "- **c_size (int, optional):** Cluster size.\n",
     "- **eps (float, optional):** Threshold for detecting changes. Default: \n",
-    "- **pertub_dev (float, optional):** Deviation for perturbation in diversity introduction. "
+    "- **perturb_dev (float, optional):** Deviation for perturbation in diversity introduction. "
    ]
   },
   {

--- a/docs/source/algorithms/moo/nsga2.ipynb
+++ b/docs/source/algorithms/moo/nsga2.ipynb
@@ -72,9 +72,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Furthermore, to increase some selection pressure, NSGA-II uses a binary tournament mating selection. Each individual is first compared by rank and then crowding distance. There is also a variant in the original C code where instead of using the rank, the domination criterium between two solutions is used."
-   ]
+   "source": "Furthermore, to increase some selection pressure, NSGA-II uses a binary tournament mating selection. Each individual is first compared by rank and then crowding distance. There is also a variant in the original C code where instead of using the rank, the domination criterion between two solutions is used."
   },
   {
    "cell_type": "markdown",

--- a/docs/source/getting_started/part_2.ipynb
+++ b/docs/source/getting_started/part_2.ipynb
@@ -166,9 +166,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "If you use **pymoo** as a researcher trying to improve existing algorithms, you might want to have a look at the varierity of single- and many-objective optimization test problems already implemented. "
-   ]
+   "source": "If you use **pymoo** as a researcher trying to improve existing algorithms, you might want to have a look at the variety of single- and many-objective optimization test problems already implemented. "
   },
   {
    "cell_type": "markdown",

--- a/pymoo/algorithms/moo/kgb.py
+++ b/pymoo/algorithms/moo/kgb.py
@@ -24,13 +24,13 @@ class KGB(NSGA2):
         c_size=13,
         eps=0.0,
         ps={},
-        pertub_dev=0.1,
+        perturb_dev=0.1,
         save_ps=False,
         **kwargs,
     ):
 
         super().__init__(**kwargs)
-        self.PERTUB_DEV = pertub_dev
+        self.PERTURB_DEV = perturb_dev
         self.PERC_DIVERSITY = perc_diversity
         self.PERC_DETECT_CHANGE = perc_detect_change
         self.EPS = eps
@@ -258,11 +258,11 @@ class KGB(NSGA2):
         :param pop: Population to check and fix boundaries
         :return: Population with corrected boundaries
         """
-        # check wether numpy array or pymoo population is given
+        # check whether numpy array or pymoo population is given
         if isinstance(pop, Population):
             pop = pop.get("X")
 
-        # check if any solution is outside of the bounds
+        # check if any solution is outside the bounds
         for individual in pop:
             for i in range(len(individual)):
                 if individual[i] > self.problem.xu[i]:
@@ -281,7 +281,7 @@ class KGB(NSGA2):
         # TODO: Check boundaries
         random_pop = np.random.random((N_r, self.problem.n_var))
 
-        # check if any solution is outside of the bounds
+        # check if any solution is outside the bounds
         for individual in random_pop:
             for i in range(len(individual)):
                 if individual[i] > self.problem.xu[i]:
@@ -341,16 +341,16 @@ class KGB(NSGA2):
             X_test = self.random_strategy(self.nr_rand_solutions)
 
             # introduce noise to vary previously useful solutions
-            noise = np.random.normal(0, self.PERTUB_DEV, self.problem.n_var)
+            noise = np.random.normal(0, self.PERTURB_DEV, self.problem.n_var)
             noisy_useful_history = np.asarray(pop_useful) + noise
 
-            # check wether solutions are within bounds
+            # check whether solutions are within bounds
             noisy_useful_history = self.check_boundaries(noisy_useful_history)
 
             # add noisy useful history to randomly generated solutions
             X_test = np.vstack((X_test, noisy_useful_history))
 
-            # predict wether random solutions are useful or useless
+            # predict whether random solutions are useful or useless
             Y_test = model.predict(X_test)
 
             # create list of useful predicted solutions
@@ -391,7 +391,7 @@ class KGB(NSGA2):
             # if there are still not enough solutions in init_pop randomly sample previously useful solutions directly without noise to init_pop
             if len(init_pop) < self.pop_size:
 
-                # fill up init_pop with randomly sampled solutions from pop_usefull
+                # fill up init_pop with randomly sampled solutions from pop_useful
                 if len(pop_useful) >= self.pop_size - len(init_pop):
 
                     nr_sampled_pop_useful = self.pop_size - len(init_pop)

--- a/pymoo/algorithms/moo/nsga3.py
+++ b/pymoo/algorithms/moo/nsga3.py
@@ -212,7 +212,7 @@ def niching(pop, n_remaining, niche_count, niche_of_individuals, dist_to_niche):
         # the minimum niche count
         min_niche_count = next_niche_count.min()
 
-        # all niches with the minimum niche count (truncate if randomly if more niches than remaining individuals)
+        # all niches with the minimum niche count (truncate randomly if there are more niches than remaining individuals)
         next_niches = next_niches_list[np.where(next_niche_count == min_niche_count)[0]]
         next_niches = next_niches[np.random.permutation(len(next_niches))[:n_select]]
 
@@ -303,7 +303,7 @@ def get_extreme_points_c(F, ideal_point, extreme_points=None):
     weights = np.eye(F.shape[1])
     weights[weights == 0] = 1e6
 
-    # add the old extreme points to never loose them for normalization
+    # add the old extreme points to never lose them for normalization
     _F = F
     if extreme_points is not None:
         _F = np.concatenate([extreme_points, _F], axis=0)

--- a/pymoo/algorithms/moo/pinsga2.py
+++ b/pymoo/algorithms/moo/pinsga2.py
@@ -167,7 +167,7 @@ class PINSGA2(GeneticAlgorithm):
                             break
                         print("Invalid input. Please enter 'a', 'b', or 'c'.")
                     
-                    # if better than currenly ranked element place before that element
+                    # if better than currently ranked element place before that element
                     if preference == 'a':
                         _ranks.insert( j, [i] )
                         inserted = True

--- a/pymoo/algorithms/moo/rnsga3.py
+++ b/pymoo/algorithms/moo/rnsga3.py
@@ -176,7 +176,7 @@ def get_ref_dirs_from_points(ref_point, ref_dirs, mu=0.1):
     Das-Dennis points around the projection of user points on the Das-Dennis hyperplane
     :param ref_point: List of user specified reference points
     :param n_obj: Number of objectives to consider
-    :param mu: Shrinkage factor (0-1), Smaller = tigher convergence, Larger= larger convergence
+    :param mu: Shrinkage factor (0-1), Smaller = tighter convergence, Larger= larger convergence
     :return: Set of reference points
     """
 
@@ -232,7 +232,7 @@ def line_plane_intersection(l0, l1, p0, p_no, epsilon=1e-6):
         # if 'fac' is between (0 - 1) the point intersects with the segment.
         # otherwise:
         #  < 0.0: behind p0.
-        #  > 1.0: infront of p1.
+        #  > 1.0: in front of p1.
         w = p0 - l0
         d = np.dot(w, p_no) / dot
         l = l * d

--- a/pymoo/config.py
+++ b/pymoo/config.py
@@ -22,7 +22,7 @@ class Config:
     # whether when import a file the doc should be parsed - only activate when creating doc files
     parse_custom_docs = False
 
-    # a method defining the endpoint to load data remotely - default from github repo
+    # a method defining the endpoint to load data remotely - default from GitHub repo
     @classmethod
     def data(cls):
         return f"https://raw.githubusercontent.com/anyoptimization/pymoo-data/main/"

--- a/pymoo/cython/non_dominated_sorting.pyx
+++ b/pymoo/cython/non_dominated_sorting.pyx
@@ -100,7 +100,7 @@ cdef vector[vector[int]] c_fast_non_dominated_sort(double[:,:] F, double epsilon
     # append the first front to the current front
     fronts.push_back(current_front)
 
-    # while not all solutions are assigned to a pareto front or we can stop early because of stop criterium
+    # while not all solutions are assigned to a pareto front or we can stop early because of stop criterion
     while (n_ranked < n_points) and (n_ranked < n_stop_if_ranked):
 
         next_front = vector[int]()

--- a/pymoo/docs.py
+++ b/pymoo/docs.py
@@ -87,7 +87,7 @@ algorithms = {
 
 visualization = {
     "figsize": """tuple
-                The figure size. Default (figsize=(8, 6)). For some plots changing the size might have side-effects for position.
+                The figure size. Default (figsize=(8, 6)). For some plots changing the size might have side effects for position.
                 """,
 
     "title": """str or tuple

--- a/pymoo/operators/selection/tournament.py
+++ b/pymoo/operators/selection/tournament.py
@@ -8,7 +8,7 @@ from pymoo.util.misc import random_permutations
 
 class TournamentSelection(Selection):
     """
-      The Tournament selection is used to simulated a tournament between individuals. The pressure balances
+      The Tournament selection is used to simulate a tournament between individuals. The pressure balances
       greedy the genetic algorithm will be.
     """
 
@@ -19,7 +19,7 @@ class TournamentSelection(Selection):
         ----------
         func_comp: func
             The function to compare two individuals. It has the shape: comp(pop, indices) and returns the winner.
-            If the function is None it is assumed the population is sorted by a criterium and only indices are compared.
+            If the function is None it is assumed the population is sorted by a criterion and only indices are compared.
 
         pressure: int
             The selection pressure to bie applied. Default it is a binary tournament.

--- a/pymoo/optimize.py
+++ b/pymoo/optimize.py
@@ -8,7 +8,7 @@ def minimize(problem, algorithm, termination=None, copy_algorithm=True, copy_ter
 
     This is used as a convenience function to execute several algorithms with default settings which turned
     out to work for a test single. However, evolutionary computations utilizes the idea of customizing a
-    meta-algorithm. Customizing the algorithm using the object oriented interface is recommended to improve the
+    meta-algorithm. Customizing the algorithm using the object-oriented interface is recommended to improve the
     convergence.
 
     Parameters
@@ -48,7 +48,7 @@ def minimize(problem, algorithm, termination=None, copy_algorithm=True, copy_ter
 
     """
 
-    # create a copy of the algorithm object to ensure no side-effects
+    # create a copy of the algorithm object to ensure no side effects
     if copy_algorithm:
         algorithm = copy.deepcopy(algorithm)
 

--- a/pymoo/problems/single/traveling_salesman.py
+++ b/pymoo/problems/single/traveling_salesman.py
@@ -14,7 +14,7 @@ class TravelingSalesman(ElementwiseProblem):
         Parameters
         ----------
         cities : numpy.array
-            The cities with 2-dimensional coordinates provided by a matrix where where city is represented by a row.
+            The cities with 2-dimensional coordinates provided by a matrix where city is represented by a row.
 
         """
         n_cities, _ = cities.shape

--- a/pymoo/visualization/heatmap.py
+++ b/pymoo/visualization/heatmap.py
@@ -32,7 +32,7 @@ class Heatmap(Plot):
             If true large values are white and small values the corresponding color. Otherwise, the other way around.
 
         solution_labels : bool or list
-            If False no labels are plotted in the y axis. If true just the corresponding index. Otherwise the label provided.
+            If False no labels are plotted in the y axis. If true just the corresponding index. Otherwise, the label provided.
 
         bounds : {bounds}
 
@@ -97,11 +97,11 @@ class Heatmap(Plot):
         if self.solution_labels is None:
             pass
 
-        # in case just true just use a number for each solution
+        # if true, just use a number for each solution
         elif isinstance(self.solution_labels, bool) and self.solution_labels:
             self.solution_labels = np.arange(len(F)) + 1
 
-        # otherwise use directly the label provided
+        # otherwise, use directly the label provided
         else:
             if len(self.solution_labels) != len(F):
                 raise Exception(

--- a/pymoo/visualization/pcp.py
+++ b/pymoo/visualization/pcp.py
@@ -36,7 +36,7 @@ class PCP(Plot):
             Whether the value of the boundaries are shown in the plot or not.
 
         normalize_each_axis : bool
-            Whether the values should be normalized either by bounds or implictly.
+            Whether the values should be normalized either by bounds or implicitly.
 
         Other Parameters
         ----------------

--- a/pymoo/visualization/radar.py
+++ b/pymoo/visualization/radar.py
@@ -21,7 +21,7 @@ class Radar(Plot):
         Parameters
         ----------------
         normalize_each_objective : bool
-            Whether each objective is normalized. Otherwise the inner and outer bound is plotted.
+            Whether each objective is normalized. Otherwise, the inner and outer bound is plotted.
         point_style : dict
             The style being used to visualize the points
         n_partitions : int


### PR DESCRIPTION
This pull request addresses minor typos found in the comments, documentation, and variable names in the source code. Specifically, the variable `pertub_dev` and `self.PERTUB_DEV` have been corrected for consistency.

Feel free to reach out if anything else is needed. Thanks for maintaining such a great repository—I use it regularly! 

Cheers,  
Arthur