### PR TITLE
fix arrow head position

### DIFF
--- a/docs/source/mcdm/index.ipynb
+++ b/docs/source/mcdm/index.ipynb
@@ -138,7 +138,7 @@
     "plot.add(F, color=\"blue\", alpha=0.2, s=10)\n",
     "plot.add(F[I], color=\"red\", s=30)\n",
     "plot.do()\n",
-    "plot.apply(lambda ax: ax.arrow(0, 0, 0.5, 0.5, color='black', \n",
+    "plot.apply(lambda ax: ax.arrow(0, 0, *weights, color='black', \n",
     "                               head_width=0.01, head_length=0.01, alpha=0.4))\n",
     "plot.show()"
    ]


### PR DESCRIPTION
Currently if weights change, the arrow keeps pointing at (0.5,0.5) because it's hard coded.


![image](https://github.com/user-attachments/assets/111e315e-480a-464e-ae69-1626ebccfc08)

Now it follows the weights variable