### PR TITLE
Removes final use of deprecated `.feasible` attribute.

### DIFF
--- a/pymoo/core/replacement.py
+++ b/pymoo/core/replacement.py
@@ -7,12 +7,12 @@ from pymoo.core.survival import Survival
 
 
 def is_better(_new, _old, eps=0.0):
-    both_infeasible = not _old.feasible[0] and not _new.feasible[0]
-    both_feasible = _old.feasible[0] and _new.feasible[0]
+    both_infeasible = not _old.feas and not _new.feas
+    both_feasible = _old.feas and _new.feas
 
     if both_infeasible and _old.CV[0] - _new.CV[0] > eps:
         return True
-    elif not _old.feasible and _new.feasible:
+    elif not _old.FEAS and _new.FEAS:
         return True
     elif both_feasible and _old.F[0] - _new.F[0] > eps:
         return True


### PR DESCRIPTION
This PR addresses a warning I received 

```bash
../../miniforge3/envs/2025-dotson-thesis/lib/python3.11/site-packages/pymoo/core/individual.py:617: 60100 warnings
  /Users/samdotson/miniforge3/envs/2025-dotson-thesis/lib/python3.11/site-packages/pymoo/core/individual.py:617: DeprecationWarning: The ``feasible`` property for ``pymoo.core.individual.Individual`` is deprecated
    v = getattr(self, key)
```

This seemed strange since `Individual` isn't a component of `pymoo` that I use explicitly. I tracked down the remaining instance of `.feasible` to `replacement.py`. 

Hopefully, this fully addresses the internal use of `.feasible` and the attribute can be retired. Though I haven't done that here.

An early attempt to resolve this warning can was from #631, but it missed a spot 😄. 