### PR TITLE
Replace `kwargs:dict` with `kwargs:any`

### DIFF
--- a/pymoo/core/individual.py
+++ b/pymoo/core/individual.py
@@ -12,6 +12,7 @@ __all__ = [
 ]
 
 import copy
+from typing import Any
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -48,7 +49,7 @@ class Individual:
     def __init__(
             self, 
             config: Optional[dict] = None, 
-            **kwargs: dict,
+            **kwargs: Any,
         ) -> None:
         """
         Constructor for the ``Invididual`` class.
@@ -58,7 +59,7 @@ class Individual:
         config : dict, None
             A dictionary of configuration metadata.
             If ``None``, use a class-dependent default configuration.
-        kwargs : dict
+        kwargs : Any
             Additional keyword arguments containing data which is to be stored 
             in the ``Individual``.
         """
@@ -553,14 +554,14 @@ class Individual:
 
     def set_by_dict(
             self, 
-            **kwargs: dict
+            **kwargs: Any
         ) -> None:
         """
         Set an individual's data or metadata using values in a dictionary.
 
         Parameters
         ----------
-        kwargs : dict
+        kwargs : Any
             Keyword arguments defining the data to set.
         """
         for k, v in kwargs.items():

--- a/pymoo/core/individual.py
+++ b/pymoo/core/individual.py
@@ -595,15 +595,15 @@ class Individual:
 
     def get(
             self, 
-            *keys: Tuple[str,...],
+            *keys: str,
         ) -> Union[tuple,object]:
         """
         Get the values for one or more keys for an individual.
 
         Parameters
         ----------
-        keys : tuple
-            A tuple of keys for which to get values.
+        keys : str
+            Keys for which to get values.
 
         Returns
         -------

--- a/pymoo/core/variable.py
+++ b/pymoo/core/variable.py
@@ -13,7 +13,7 @@ __all__ = [
     "get",
 ]
 
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 from typing import Union
 import numpy as np
 from numpy.typing import ArrayLike
@@ -111,14 +111,14 @@ class Variable(object):
 
     def get(
             self, 
-            **kwargs: dict
+            **kwargs: Any
         ) -> object:
         """
         Get the value of a decision variable.
 
         Parameters
         ----------
-        kwargs : dict
+        kwargs : Any
             Additional keyword arguments.
         
         Returns
@@ -139,7 +139,7 @@ class BoundedVariable(Variable):
             value: Optional[object] = None, 
             bounds: Tuple[Optional[object],Optional[object]] = (None, None), 
             strict: Optional[Tuple[Optional[object],Optional[object]]] = None, 
-            **kwargs: dict,
+            **kwargs: Any,
         ) -> None:
         """
         Constructor for the ``BoundedVariable`` class.
@@ -154,7 +154,7 @@ class BoundedVariable(Variable):
         strict : tuple, None
             Strict boundaries for the decision variable.
             If ``None``, the value of ``bounds`` is copied to ``strict``.
-        kwargs : dict
+        kwargs : Any
             Additional keyword arguments for ``active`` and ``flag``.
         """
         # call the Variable constructor 
@@ -302,7 +302,7 @@ class Choice(Variable):
             value: Optional[object] = None, 
             options: Optional[ArrayLike] = None, 
             all: Optional[ArrayLike] = None, 
-            **kwargs: dict,
+            **kwargs: Any,
         ) -> None:
         """
         Constructor for the ``Choice`` class.
@@ -316,7 +316,7 @@ class Choice(Variable):
         all : ArrayLike, None
             A strict list of decision variable options from which to choose.
             If ``None``, the value of ``options`` is copied to ``all``.
-        kwargs : dict
+        kwargs : Any
             Additional keyword arguments for ``active`` and ``flag``.
         """
         # all super constructor
@@ -357,7 +357,7 @@ class Choice(Variable):
 def get(
         *args: Tuple[Union[Variable,object],...], 
         size: Optional[Union[tuple,int]] = None, 
-        **kwargs: dict
+        **kwargs: Any
     ) -> Union[tuple,object,None]:
     """
     Get decision variable values from a tuple of ``Variable`` objects.
@@ -368,7 +368,7 @@ def get(
         A tuple of ``Variable`` or ``object``s.
     size : tuple, int, None
         Size to reshape decision variables.
-    kwargs : dict
+    kwargs : Any
         Additional keyword arguments to pass to the ``get`` method of the 
         ``Variable`` class when getting decision variable values.
     


### PR DESCRIPTION
In the code kwargs are typed as dict.  
According to the python typing manual:
>At runtime, the type of a variadic positional parameter (*args) is a tuple, and the type of a variadic keyword parameter (**kwargs) is a dict. However, when annotating these parameters, the **type annotation refers to the type of items within the tuple or dict** (unless Unpack is used).
[Source](https://typing.python.org/en/latest/spec/callables.html#annotating-args-and-kwargs)

This PR adapts the type hints accordingly.