### PR TITLE
don't include cythonized cpp files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 exclude tests/*
+exclude pymoo/cython/*.cpp
 recursive-include pymoo *.pyx *.pxd
-recursive-include pymoo/cython/vendor *.cpp *.h
+recursive-include pymoo/cython/vendor *.h
 include Makefile

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 exclude tests/*
 exclude pymoo/cython/*.cpp
-recursive-include pymoo *.pyx *.pxd
-recursive-include pymoo/cython/vendor *.h
+include pymoo/cython/*.pyx 
+include pymoo/cython/*.pxd
+include pymoo/cython/vendor/*.h
 include Makefile


### PR DESCRIPTION
Modify MANIFEST.in to skip including cython/*.cpp files in the sdist, which are autogenerated.

(I've also checked that the wheels don't include these files too, after this change).
