### PR TITLE
correct license specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pymoo"
 description = "Multi-Objective Optimization in Python"
 authors = [{ name = "Julian Blank", email = "blankjul@outlook.com" }]
 readme = "README.rst"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 classifiers = [
     'Intended Audience :: Developers',
     'Intended Audience :: Science/Research',


### PR DESCRIPTION
Minor tweak to match the specification for the license field: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
