### PR TITLE
Fix SBX prob_bin parameter to control parent exchange probability

### DIFF
--- a/docs/source/algorithms/soo/nrbo.md
+++ b/docs/source/algorithms/soo/nrbo.md
@@ -6,15 +6,15 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.17.1
 kernelspec:
-  name: default
   display_name: default
   language: python
+  name: default
 ---
 
 ```{raw-cell}
 ---
-raw_mimetype: text/restructuredtext
 editable: true
+raw_mimetype: text/restructuredtext
 slideshow:
   slide_type: ''
 ---
@@ -100,7 +100,7 @@ print("Constraint violation: %s" % res.CV)
 
 ### Performance Comparison
 
-Here's an example comparing NRBO with other single-objective algorithms:
+Here's an example comparing NRBO with other single-objective algorithms including G3PCX:
 
 ```{code-cell} ipython3
 import numpy as np
@@ -108,6 +108,7 @@ import matplotlib.pyplot as plt
 from pymoo.algorithms.soo.nonconvex.nrbo import NRBO
 from pymoo.algorithms.soo.nonconvex.ga import GA
 from pymoo.algorithms.soo.nonconvex.pso import PSO
+from pymoo.algorithms.soo.nonconvex.g3pcx import G3PCX
 from pymoo.problems import get_problem
 from pymoo.optimize import minimize
 
@@ -118,7 +119,8 @@ problem = get_problem("rastrigin", n_var=10)
 algorithms = [
     ("NRBO", NRBO(pop_size=50)),
     ("GA", GA(pop_size=50)),
-    ("PSO", PSO(pop_size=50))
+    ("PSO", PSO(pop_size=50)),
+    ("G3PCX", G3PCX(pop_size=50))
 ]
 
 # Run optimizations and collect results

--- a/pymoo/operators/crossover/sbx.py
+++ b/pymoo/operators/crossover/sbx.py
@@ -25,9 +25,14 @@ def cross_sbx(X, xl, xu, eta, prob_var, prob_bin, eps=1.0e-14):
     # disable crossover when lower and upper bound are identical
     cross[:, xl == xu] = False
 
-    # assign y1 the smaller and y2 the larger value
-    y1 = np.min(X, axis=0)[cross]
-    y2 = np.max(X, axis=0)[cross]
+    # preserve parent identity while getting values for SBX calculation
+    p1 = X[0][cross]
+    p2 = X[1][cross]
+    
+    # assign y1 the smaller and y2 the larger value for SBX calculation
+    sm = p1 < p2
+    y1 = np.where(sm, p1, p2)
+    y2 = np.where(sm, p2, p1)
 
     # mask all the values that should be crossovered
     _xl = np.repeat(xl[None, :], n_matings, axis=0)[cross]
@@ -60,18 +65,20 @@ def cross_sbx(X, xl, xu, eta, prob_var, prob_bin, eps=1.0e-14):
     betaq = calc_betaq(beta)
     c2 = 0.5 * ((y1 + y2) + betaq * delta)
 
-    # with the given probability either assign the value from the first or second parent
+    # assign children based on parent position, then apply exchange probability
+    child1 = np.where(sm, c1, c2)  # child for parent 1
+    child2 = np.where(sm, c2, c1)  # child for parent 2
+    
+    # exchange children with given probability
     b = np.random.random(len(prob_bin)) < prob_bin
-    tmp = np.copy(c1[b])
-    c1[b] = c2[b]
-    c2[b] = tmp
+    child1, child2 = np.where(b, (child2, child1), (child1, child2))
 
     # first copy the unmodified parents
     Q = np.copy(X)
 
     # copy the positions where the crossover was done
-    Q[0, cross] = c1
-    Q[1, cross] = c2
+    Q[0, cross] = child1
+    Q[1, cross] = child2
 
     Q[0] = repair_clamp(Q[0], xl, xu)
     Q[1] = repair_clamp(Q[1], xl, xu)


### PR DESCRIPTION
## Summary

This PR fixes the `prob_bin` parameter in the SBX (Simulated Binary Crossover) implementation to properly control the probability of parent value exchange.

## Problem

The current implementation has a semantic issue where `prob_bin` controls random swapping based on value magnitude rather than parent identity. This creates inconsistent behavior depending on which parent has larger/smaller values.

## Solution

- Preserve parent identity during SBX crossover calculations
- Make `prob_bin` represent the probability that parents exchange values
- Ensure Child 1 inherits characteristics from Parent 1 when `prob_bin=0.0`
- Use cleaner `np.where` syntax for child assignment and exchange

## Behavior

With this fix:
- `prob_bin=0.0`: Child1←Parent1, Child2←Parent2 (no exchange)
- `prob_bin=0.25`: 25% chance of exchange (Child1←Parent2, Child2←Parent1) 
- `prob_bin=0.5`: 50% chance of exchange (equivalent to old behavior)
- `prob_bin=1.0`: Always exchange (Child1←Parent2, Child2←Parent1)

## Backward Compatibility

The fix maintains equivalent behavior at `prob_bin=0.5` (the default), ensuring backward compatibility while providing the correct semantics at other values.

Addresses #673