### PR TITLE
Update dnsga2.py

### DIFF
--- a/pymoo/algorithms/moo/dnsga2.py
+++ b/pymoo/algorithms/moo/dnsga2.py
@@ -23,6 +23,10 @@ class DNSGA2(NSGA2):
         assert not problem.has_constraints(), "DNSGA2 only works for unconstrained problems."
         return super().setup(problem, **kwargs)
 
+    def _infill(self):
+        
+        return None
+
     def _advance(self, **kwargs):
 
         pop = self.pop

--- a/pymoo/algorithms/moo/kgb.py
+++ b/pymoo/algorithms/moo/kgb.py
@@ -52,7 +52,10 @@ class KGB(NSGA2):
             not problem.has_constraints()
         ), "KGB-DMOEA only works for unconstrained problems."
         return super().setup(problem, **kwargs)
-    
+
+    def _infill(self):
+
+        return None
 
     def knowledge_reconstruction_examination(self):
         """


### PR DESCRIPTION
In the DNSGA2.py file, since the `_advance` method was overridden, the `_infill` method becomes unnecessary and would only result in additional, redundant function evaluations.