### PR TITLE
fix NoCrossover missing offsprings

### DIFF
--- a/pymoo/operators/crossover/nox.py
+++ b/pymoo/operators/crossover/nox.py
@@ -5,8 +5,8 @@ from pymoo.core.population import Population
 
 
 class NoCrossover(Crossover):
-    def __init__(self, *, n_parents=1, n_offsprings=1, prob=0.0, **kwargs):
-        super().__init__(n_parents, n_offsprings, prob, **kwargs)
+    def __init__(self, *, n_parents=1, prob=0.0, **kwargs):
+        super().__init__(n_parents, n_parents, prob, **kwargs)
 
     def do(self, problem, pop, *args, random_state, **kwargs):
         return Population.create(*itertools.chain.from_iterable(pop))


### PR DESCRIPTION
Resolves #743 

`NoCrossover` does random selection which fails to propagate certain parents.
This PR ensures that all parents are propagated as offsprings.


Thanks @oxinabox for the catch.