### PR TITLE
Fix: Allow optional installation of matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ requires-python = ">= 3.9"
 dependencies = [
     "numpy>=1.19.3",
     "scipy>=1.1",
-    "matplotlib>=3",
     "autograd>=1.4",
     "cma>=3.2.2",
     "moocore>=0.1.7",


### PR DESCRIPTION
First of all: Excuse me for not opening an issue first, but the fix is so small that I thought I might as well :D 

I discovered that matplotlib is listed as a hard dependency in `pyproject.toml` which will always be installed. 
This contradicts the optional `pymoo[visualization]` depency and the wrapper implemented for matplotlib in `pymoo.visualization.matplotlib`. 

I suspect that the entry was falsely copied over when migrating from the `setup.py` to pyproject.toml.

Thank you very much