### PR TITLE
Fix strength calculation axis in SPEA2Survival._do to match SPEA2 algorithm definition

### DIFF
--- a/pymoo/algorithms/moo/spea2.py
+++ b/pymoo/algorithms/moo/spea2.py
@@ -39,7 +39,7 @@ class SPEA2Survival(Survival):
         M = Dominator().calc_domination_matrix(F)
 
         # the number of solutions each individual dominates
-        S = (M == 1).sum(axis=0)
+        S = (M == 1).sum(axis=1)
 
         # the raw fitness of each solution - strength of its dominators
         R = ((M == -1) * S).sum(axis=1)


### PR DESCRIPTION
This pull request resolves [anyoptimization/pymoo#748](https://github.com/anyoptimization/pymoo/issues/748) by correcting the axis used for strength calculation in the `SPEA2Survival._do` method.
Previously, strength `S` was computed as `S = (M == 1).sum(axis=0)`, which incorrectly counts the number of times each individual is dominated by others.
According to the SPEA2 algorithm (see Zitzler, E., Laumanns, M., & Thiele, L. (2001). _SPEA2: Improving the Strength Pareto Evolutionary Algorithm_. TIK-Report 103), strength should be calculated as the number of individuals each solution dominates: `S = (M == 1).sum(axis=1)`.