### PR TITLE
Fix MANIFEST.in to point to new cython path

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,4 @@
 exclude tests/*
-exclude pymoo/cython/*.cpp
-include pymoo/cython/*.pyx 
-include pymoo/cython/*.pxd
-include pymoo/cython/vendor/*.h
+include pymoo/functions/compiled/*.pyx
+include pymoo/functions/compiled/*.pxd
 include Makefile


### PR DESCRIPTION
Current conda build of pymoo fails because *.pyx files are not copied when pip creates an isolated build environment.
It seems the MANIFEST.in was not changed during the Cython refactoring. For the automated conda build to work, you would need to publish a new version of the package once you have merged the fix.

(We could also move the content of MANIFEST.in to pyproject.toml.)
