### PR TITLE
Minor clarifications to problem definition docs

### DIFF
--- a/docs/source/problems/definition.md
+++ b/docs/source/problems/definition.md
@@ -88,7 +88,7 @@ class SphereWithConstraint(Problem):
         out["G"] = 0.1 - out["F"]
 ```
 
-Assuming the algorithm being used requests to evaluate a set of 100 solutions, the input NumPy matrix `x`  will be of the shape `(100,10)`. Please note that the two-dimensional matrix is summed up along each row, which results in a column vector of length 100 for `out["F"]`. NumPy performs vectorized operations on the matrix to speed up the evaluation.
+Assuming the algorithm being used requests to evaluate a set of 100 solutions, the input NumPy matrix `x` will be of the shape `(100,10)`. Please note that the two-dimensional matrix is summed up along each row, which results in a vector of length 100 for `out["F"]`. NumPy performs vectorized operations on the matrix to speed up the evaluation.
 
 ```{raw-cell}
 :raw_mimetype: text/restructuredtext


### PR DESCRIPTION
Notes on changes, in the order they appear in the file:
- "Retrieves a set of solutions" sounds like the function's main job is to retrieve, and maybe return, the set of solutions. "Receives" clarifies that the function takes the solutions as an argument and does further work on them. There's a similar "retrieves" → "receives" change later in the file.
- "Python" should be capitalized. "NumPy" should too, given it's capitalized elsewhere in this file.
- `F_list` and `F_list_of_lists` were seemingly used to refer to the same example variable.
- Fixed grammar of "How the ... values are calculate is irrelevant from a pymoo's point of view."
- Fixed grammar and clarity of exact lower and upper bounds in "The problem consists of ... the lower and upper bounds of each variable are in the range of 0 and 1."
- "Set of 100 solutions" is as clear as "set of solutions of size 100" and avoids the (unlikely) ambiguity that "of size 100" applies to each solution rather than the set.
- "Summed up on the first axis" shouldn't be used to mean the axis with index 1, which is really the second axis, since NumPy axes are numbered starting from 0. I think "summed up along each row" is clear.
- ". . . the first variables should cover a different range of values" misstated the number of variables (only the first *one*). I also thought "have different bounds" was more appropriate here than "cover a different range of values."
- The remaining few changes were meant to improve awkward phrasing.