### PR TITLE
Fix SPEA2 truncation selection

### DIFF
--- a/pymoo/algorithms/moo/spea2.py
+++ b/pymoo/algorithms/moo/spea2.py
@@ -102,7 +102,8 @@ class SPEA2Survival(Survival):
 
             # remove one individual per loop, until we hit n_survive
             while len(survivors) > n_survive:
-                i = dists[survivors][:, survivors].min(axis=1).argmin()
+                D = dists[np.ix_(survivors, survivors)]
+                i = np.lexsort(np.sort(D, axis=1).T[::-1])[0]
                 survivors = [survivors[j] for j in range(len(survivors)) if j != i]
 
         return pop[survivors]
@@ -188,4 +189,3 @@ class SPEA2(GeneticAlgorithm):
 
 
 parse_doc_string(SPEA2.__init__)
-

--- a/pymoo/algorithms/moo/spea2.py
+++ b/pymoo/algorithms/moo/spea2.py
@@ -14,6 +14,18 @@ from pymoo.util.dominator import Dominator
 from pymoo.util.misc import vectorized_cdist
 
 
+def _truncation_candidate(dists, survivors):
+    """Return the local index of the SPEA2 survivor to truncate.
+
+    SPEA2 compares the sorted distance vectors lexicographically when the
+    archive contains too many non-dominated solutions. This uses the nearest
+    distance first and, in tie cases, the second nearest distance, then the
+    third nearest distance, and so on.
+    """
+    D = dists[np.ix_(survivors, survivors)]
+    return np.lexsort(np.sort(D, axis=1).T[::-1])[0]
+
+
 # ---------------------------------------------------------------------------------------------------------
 # Environmental Survival (in the original paper it is referred to as archiving)
 # ---------------------------------------------------------------------------------------------------------
@@ -102,8 +114,7 @@ class SPEA2Survival(Survival):
 
             # remove one individual per loop, until we hit n_survive
             while len(survivors) > n_survive:
-                D = dists[np.ix_(survivors, survivors)]
-                i = np.lexsort(np.sort(D, axis=1).T[::-1])[0]
+                i = _truncation_candidate(dists, survivors)
                 survivors = [survivors[j] for j in range(len(survivors)) if j != i]
 
         return pop[survivors]

--- a/tests/algorithms/test_spea2.py
+++ b/tests/algorithms/test_spea2.py
@@ -28,3 +28,24 @@ def test_spea2_truncation_keeps_extreme_solutions():
             [0.0, 2.0],
         ])
     )
+
+
+def test_spea2_truncation_preserves_extremes_after_multiple_removals():
+    F = np.array([
+        [3.0, 0.0],
+        [2.0, 1.0],
+        [1.0, 2.0],
+        [0.0, 3.0],
+    ])
+
+    pop = Population.new(F=F)
+    survival = SPEA2Survival()
+    survivors = survival.do(NoConstraintsProblem(), pop, n_survive=2)
+
+    np.testing.assert_array_equal(
+        survivors.get("F"),
+        np.array([
+            [3.0, 0.0],
+            [0.0, 3.0],
+        ])
+    )

--- a/tests/algorithms/test_spea2.py
+++ b/tests/algorithms/test_spea2.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from pymoo.algorithms.moo.spea2 import SPEA2Survival
+from pymoo.core.population import Population
+
+
+class NoConstraintsProblem:
+
+    def has_constraints(self):
+        return False
+
+
+def test_spea2_truncation_keeps_extreme_solutions():
+    F = np.array([
+        [2.0, 0.0],
+        [1.0, 1.0],
+        [0.0, 2.0],
+    ])
+
+    pop = Population.new(F=F)
+    survival = SPEA2Survival()
+    survivors = survival.do(NoConstraintsProblem(), pop, n_survive=2)
+
+    np.testing.assert_array_equal(
+        survivors.get("F"),
+        np.array([
+            [2.0, 0.0],
+            [0.0, 2.0],
+        ])
+    )


### PR DESCRIPTION
Fixes #773

This PR updates SPEA2 survival truncation to use lexicographical ordering of sorted distances when too many non-dominated solutions are present.

Previously, the truncation step only considered the nearest-neighbor distance, which could remove an extreme non-dominated solution in tie cases. The updated implementation compares the sorted distance rows lexicographically, as required by the SPEA2 truncation procedure.

A regression test was added for the minimal example from the issue, checking that the extreme points are preserved when reducing three non-dominated points to two survivors.

Test:
python -m pytest tests/algorithms/test_spea2.py -q
